### PR TITLE
adds ca-certificates to the alpine image

### DIFF
--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -5,5 +5,6 @@ COPY . .
 RUN make build
 
 FROM alpine:3.10
+RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
 COPY --from=0 /go/src/github.com/optimizely/sidedoor/bin/sidedoor /sidedoor
 CMD ["/sidedoor"]


### PR DESCRIPTION
should resolve these errors found in `docker logs -f sidedoor`

> {"level":"error","sdkKey":"xxxxxxxx","error":"Get https://cdn.optimizely.com/datafiles/UEeRJy1PfrfrEM6pGCGdz6.json: x509: certificate signed by unknown authority","time":"2019-10-02T00:22:02Z","message":"Initializing OptimizelyClient"}