### PR TITLE
add certs to scratch image

### DIFF
--- a/scripts/dockerfiles/Dockerfile.static
+++ b/scripts/dockerfiles/Dockerfile.static
@@ -5,5 +5,6 @@ COPY . .
 RUN make ci_build_static_binary
 
 FROM scratch
+COPY --from=0 /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=0 /go/src/github.com/optimizely/sidedoor/bin/sidedoor /sidedoor
 CMD ["/sidedoor"]


### PR DESCRIPTION
this adds ca-certs to the scratch docker image for the minimal sidedoor build