### PR TITLE
(fix): MaxConcurrency is causing too many open files when set to queue size …

### DIFF
--- a/pkg/event/nsq_queue.go
+++ b/pkg/event/nsq_queue.go
@@ -177,7 +177,7 @@ func NewNSQueue(queueSize int, address string, startDaemon, startProducer, start
 
 	var p *snsq.Producer
 	var err error
-	nsqConfig := snsq.ProducerConfig{Address:NsqListenSpec, Topic:NsqTopic, MaxConcurrency:queueSize}
+	nsqConfig := snsq.ProducerConfig{Address:NsqListenSpec, Topic:NsqTopic}
 
 	if startProducer {
 		p, err = snsq.NewProducer(nsqConfig)


### PR DESCRIPTION
…passed in.  Using default of 1