### PR TITLE
apt has trouble with version starting with v

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ jobs:
       name: linux
       os: linux
       dist: xenial
-      env: GIMME_GO_VERSION=1.12.9 GIMME_OS=linux GIMME_ARCH=amd64 VERSION=$TRAVIS_TAG
+      env: GIMME_GO_VERSION=1.12.9 GIMME_OS=linux GIMME_ARCH=amd64 VERSION=${TRAVIS_TAG:1}
       script:
         # now we're going to create packages
         - $TRAVIS_BUILD_DIR/scripts/ci_create_packages.sh


### PR DESCRIPTION
the new versioning convention introduces git tags that start with v
this change will ensure that the leading v will be excluded when
packages are being created. eg.
GIT_TAG = TRAVIS_TAG = v0.2.0
then
VERSION = 0.2.0 = DOCKER_TAG and versioning in rpm/deb packages