### PR TITLE
fix (NSQ queue test): Call queue Get method every time in Eventually callback

### DIFF
--- a/pkg/event/nsq_queue_test.go
+++ b/pkg/event/nsq_queue_test.go
@@ -99,8 +99,7 @@ func TestNSQQueue_Add_Get_Size_Remove(t *testing.T) {
 	q.Add(impression)
 	q.Add(conversion)
 
-	items1 := q.Get(3)
-	assert.Eventually(t, func() bool { return len(items1) == 3 }, 5*time.Second, 10*time.Millisecond)
+	assert.Eventually(t, func() bool { return len(q.Get(3)) == 3 }, 5*time.Second, 10*time.Millisecond)
 
 	q.Remove(1)
 	items2 := q.Get(3)


### PR DESCRIPTION
This test should be checking the length of items returned from `q.Get(3)` every time.