### PR TITLE
Run Source Clear manually to allow builds to fail if vulnerabilities are detected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,6 @@ jobs:
       name: srcclr
       os: linux
       dist: xenial
-      addons:
-        srcclr: true
       install:
         - curl -sSL https://www.sourceclear.com/install | bash
       script:

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 )
 
 exclude (
+	github.com/coreos/etcd v3.3.10+incompatible
 	github.com/coreos/etcd v3.3.11+incompatible
 	github.com/coreos/etcd v3.3.12+incompatible
 	github.com/coreos/etcd v3.3.13+incompatible


### PR DESCRIPTION
When srcclr is triggered via travis "addon", builds will succeed even if vulnerabilities are found. Running srcclr manually allows us to fail the build when vulnerabilities are found so that they become more noticeable.

If no issues, no output: https://travis-ci.com/optimizely/sidedoor/jobs/274017520#L266
if there issues, it displays the number of vulnerabilities and shows what they are: https://travis-ci.com/optimizely/sidedoor/jobs/274016389#L266 and most importantly, fails the build.