### PR TITLE
verify that optimizely.exe actually works

### DIFF
--- a/scripts/check_exe.ps1
+++ b/scripts/check_exe.ps1
@@ -3,7 +3,7 @@ Write-Host "Checking if bin\optimizely.exe works..." -ForegroundColor Green
 $OPTLY_PID = Start-Process -Filepath "bin\optimizely.exe" -NoNewWindow -PassThru
 Start-Sleep -s 5
 
-if( Invoke-RestMethod -uri 127.0.0.1:8088/health -Method Get | Where-Object { $_.status -match "oka" } ){
+if( Invoke-RestMethod -uri 127.0.0.1:8088/health -Method Get | Where-Object { $_.status -match "ok" } ){
   Write-Host "Success: /health endpoint is working"
 }else{
   Write-Host "Stopping bin\optimizely.exe..." -ForegroundColor Green


### PR DESCRIPTION
after optimizely.exe is generated, we check the /health endpoint to make sure it says ok otherwise build will fail