### PR TITLE
Add Agent version and name.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,8 +23,7 @@ MAKEFLAGS += --silent
 # Use linker flags to strip debugging info from the binary.
 # -s Omit the symbol table and debug information.
 # -w Omit the DWARF symbol table.
-LDFLAGS=-ldflags "-s -w -X main.Version=${APP_VERSION}"
-
+LDFLAGS=-ldflags "-s -w -X main.Version=${APP_VERSION} -X github.com/optimizely/go-sdk/pkg/event.ClientName=Agent -X github.com/optimizely/go-sdk/pkg/event.Version=${APP_VERSION}"
 .PHONY: all lint clean
 
 all: test lint build ## runs the test, lint and build targets

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-chi/render v1.0.1
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
-	github.com/optimizely/go-sdk v1.0.0-rc1.0.20200108174332-d1b332cb2875
+	github.com/optimizely/go-sdk v1.0.1-0.20200114173901-d19671f9b324
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rs/zerolog v1.15.0
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/optimizely/go-sdk v1.0.0-rc1.0.20200108174332-d1b332cb2875 h1:MHBjX78yNlbkuibW2l5gkkTvrZH4uiAbn8ZqYKbBF7g=
-github.com/optimizely/go-sdk v1.0.0-rc1.0.20200108174332-d1b332cb2875/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
+github.com/optimizely/go-sdk v1.0.1-0.20200114173901-d19671f9b324 h1:GI+WgzWlJO2J154xZ69QWl35U0mW9TyI1h58/flsWOg=
+github.com/optimizely/go-sdk v1.0.1-0.20200114173901-d19671f9b324/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
## Summary
* Set's the ClientName and Version as part of the build

Client name and version are included in the log requests to Optimizely to track adoption. We want to be able to distinguish Agent requests from native go-sdk requests.