### PR TITLE
Clean up docs and pull latest go-sdk.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: $(TARGET) check-go ## builds and installs binary in bin/
 
 check-go:
 ifndef GOPATH
-	$(error "go is not available please install golang, https://golang.org/dl/")
+	$(error "go is not available please install golang version 1.13+, https://golang.org/dl/")
 endif
 
 clean: check-go ## runs `go clean` and removes the bin/ dir

--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ curl localhost:8088/metrics
 ```
 
 Example Response:
-```json
+```
 {
     "cmdline": [
         "bin/optimizely"
@@ -176,8 +176,8 @@ Example Response:
         "HeapAlloc": 924136,
         ...
         "Frees": 172
-	},
-	...
+    },
+    ...
 }
 ```
 Custom metrics are also provided for the individual service endpoints and follow the pattern of:

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-chi/render v1.0.1
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
-	github.com/optimizely/go-sdk v1.0.1-0.20200114173901-d19671f9b324
+	github.com/optimizely/go-sdk v1.0.1-0.20200115172509-b75e05a48376
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rs/zerolog v1.15.0
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/optimizely/go-sdk v1.0.1-0.20200114173901-d19671f9b324 h1:GI+WgzWlJO2J154xZ69QWl35U0mW9TyI1h58/flsWOg=
-github.com/optimizely/go-sdk v1.0.1-0.20200114173901-d19671f9b324/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
+github.com/optimizely/go-sdk v1.0.1-0.20200115172509-b75e05a48376 h1:7UXN4lJu2DNJbHjyXY7ahVlHyyicIwI9SsUHMZOJZUI=
+github.com/optimizely/go-sdk v1.0.1-0.20200115172509-b75e05a48376/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -2,11 +2,11 @@ ARG GO_VERSION
 FROM golang:$GO_VERSION-alpine3.10 as builder
 # hadolint ignore=DL3018
 RUN apk add --no-cache make gcc libc-dev git
-WORKDIR /go/src/github.com/optimizely/sidedoor
+WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
 RUN make build
 
 FROM alpine:3.10
 RUN apk add --no-cache ca-certificates=20190108-r0
-COPY --from=builder /go/src/github.com/optimizely/sidedoor/bin/optimizely /optimizely
+COPY --from=builder /go/src/github.com/optimizely/agent/bin/optimizely /optimizely
 CMD ["/optimizely"]

--- a/scripts/dockerfiles/Dockerfile.static
+++ b/scripts/dockerfiles/Dockerfile.static
@@ -1,11 +1,11 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION as builder
 
-WORKDIR /go/src/github.com/optimizely/sidedoor
+WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
 RUN make ci_build_static_binary
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=builder /go/src/github.com/optimizely/sidedoor/bin/optimizely /optimizely
+COPY --from=builder /go/src/github.com/optimizely/agent/bin/optimizely /optimizely
 CMD ["/optimizely"]


### PR DESCRIPTION
## Summary
* Update to latest go-sdk master to fix /features and /experiments responses
* Moved "Running Optimizely via Docker" after "... via Source"
* Add more content to README.md.
* Document Golang 1.13+ dependency
* Update docker files to pull from /agent

Several smallish enhancements I felt easier to roll into a single commit. The documentation is still highly geared towards operations and developing Agent. The descriptions of the Full Stack API is pretty limited providing just the basic concepts as we'll defer to generated API docs and the developer site for more Agent consumer content.