### PR TITLE
Refactor overrides into it's own API set

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -244,11 +244,10 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           description: Feature does not exist
-  /overrides/users/{userId}/experiments/{experimentKey}/variations/{variationKey}:
+  /overrides/users/{userId}/experiments/{experimentKey}:
     parameters:
       - $ref: '#/components/parameters/userIdParam'
       - $ref: '#/components/parameters/experimentKeyParam'
-      - $ref: '#/components/parameters/variationKeyParam'
     put:
       summary: Set a forced variation for a user in an experiment
       operationId: setForcedVariation
@@ -256,7 +255,7 @@ paths:
         based decisions. This override is only stored locally and inmemory for debugging and testing purposes
         and should not be used for production overrides.
       tags:
-        - users
+        - overrides
       responses:
         '201':
           description: Forced variation set
@@ -266,16 +265,14 @@ paths:
           description: Invalid user id, experiment key, or variation key
         '403':
           $ref: '#/components/responses/Forbidden'
-  /overrides/users/{userId}/experiments/{experimentKey}/variations:
-    parameters:
-      - $ref: '#/components/parameters/userIdParam'
-      - $ref: '#/components/parameters/experimentKeyParam'
+      requestBody:
+        $ref: '#/components/requestBodies/Override'
     delete:
       summary: Remove any forced variation for a user in an experiment
       operationId: deleteForcedVariation
       description: Delete forced variation removes any stored variation override associated with the user and experiment.
       tags:
-        - users
+        - overrides
       responses:
         '204':
           description: Any forced variation was deleted
@@ -336,6 +333,12 @@ components:
           schema:
             type: object
             additionalProperties: true
+    Override:
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Override'
   responses:
     Forbidden:
       description: You do not have necessary permissions for the resource
@@ -396,6 +399,10 @@ components:
       required:
       - id
       - key
+    Override:
+      properties:
+        variationKey:
+          type: string
     Variation:
       properties:
         id:
@@ -435,5 +442,9 @@ tags:
       url: https://docs.developers.optimizely.com/full-stack/docs/welcome
   - name: users
     description: Collection of APIs to make decisions given the context of a specified user.
+    externalDocs:
+      url: https://docs.developers.optimizely.com/full-stack/docs/welcome
+  - name: overrides
+    description: Collection of APIs used to override the default decision logic.
     externalDocs:
       url: https://docs.developers.optimizely.com/full-stack/docs/welcome

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -154,45 +154,6 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           description: Experiment does not exist
-  /users/{userId}/experiments/{experimentKey}/variations/{variationKey}:
-    parameters:
-    - $ref: '#/components/parameters/userIdParam'
-    - $ref: '#/components/parameters/experimentKeyParam'
-    - $ref: '#/components/parameters/variationKeyParam'
-    put:
-      summary: Set a forced variation for a user in an experiment
-      operationId: setForcedVariation
-      description: Set forced variation stores the experiment and variation detail to be consumed by future user
-                   based decisions. This override is only stored locally and inmemory for debugging and testing purposes
-                   and should not be used for production overrides.
-      tags:
-        - users
-      responses:
-        '201':
-          description: Forced variation set
-        '204':
-          description: Forced variation was already set
-        '400':
-          description: Invalid user id, experiment key, or variation key
-        '403':
-          $ref: '#/components/responses/Forbidden'
-  /users/{userId}/experiments/{experimentKey}/variations:
-    parameters:
-    - $ref: '#/components/parameters/userIdParam'
-    - $ref: '#/components/parameters/experimentKeyParam'
-    delete:
-      summary: Remove any forced variation for a user in an experiment
-      operationId: deleteForcedVariation
-      description: Delete forced variation removes any stored variation override associated with the user and experiment.
-      tags:
-        - users
-      responses:
-        '204':
-          description: Any forced variation was deleted
-        '400':
-          description: Invalid user id or experiment key
-        '403':
-          $ref: '#/components/responses/Forbidden'
   /users/{userId}/features:
     parameters:
       - $ref: '#/components/parameters/userIdParam'
@@ -283,6 +244,45 @@ paths:
           $ref: '#/components/responses/Forbidden'
         '404':
           description: Feature does not exist
+  /overrides/users/{userId}/experiments/{experimentKey}/variations/{variationKey}:
+    parameters:
+      - $ref: '#/components/parameters/userIdParam'
+      - $ref: '#/components/parameters/experimentKeyParam'
+      - $ref: '#/components/parameters/variationKeyParam'
+    put:
+      summary: Set a forced variation for a user in an experiment
+      operationId: setForcedVariation
+      description: Set forced variation stores the experiment and variation detail to be consumed by future user
+        based decisions. This override is only stored locally and inmemory for debugging and testing purposes
+        and should not be used for production overrides.
+      tags:
+        - users
+      responses:
+        '201':
+          description: Forced variation set
+        '204':
+          description: Forced variation was already set
+        '400':
+          description: Invalid user id, experiment key, or variation key
+        '403':
+          $ref: '#/components/responses/Forbidden'
+  /overrides/users/{userId}/experiments/{experimentKey}/variations:
+    parameters:
+      - $ref: '#/components/parameters/userIdParam'
+      - $ref: '#/components/parameters/experimentKeyParam'
+    delete:
+      summary: Remove any forced variation for a user in an experiment
+      operationId: deleteForcedVariation
+      description: Delete forced variation removes any stored variation override associated with the user and experiment.
+      tags:
+        - users
+      responses:
+        '204':
+          description: Any forced variation was deleted
+        '400':
+          description: Invalid user id or experiment key
+        '403':
+          $ref: '#/components/responses/Forbidden'
 components:
   parameters:
     attributesParam:

--- a/pkg/handlers/interface.go
+++ b/pkg/handlers/interface.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -44,6 +44,10 @@ type UserAPI interface {
 
 	ActivateExperiment(w http.ResponseWriter, r *http.Request)
 	GetVariation(w http.ResponseWriter, r *http.Request)
+}
+
+// UserOverrideAPI defines supported override functionality
+type UserOverrideAPI interface {
 	SetForcedVariation(w http.ResponseWriter, r *http.Request)
 	RemoveForcedVariation(w http.ResponseWriter, r *http.Request)
 }

--- a/pkg/handlers/user.go
+++ b/pkg/handlers/user.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -18,7 +18,6 @@
 package handlers
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
@@ -145,60 +144,6 @@ func (h *UserHandler) ActivateExperiment(w http.ResponseWriter, r *http.Request)
 	}
 
 	renderVariation(w, r, experiment.Key, true, optlyClient, optlyContext) // true to send impression
-}
-
-// SetForcedVariation - set a forced variation
-func (h *UserHandler) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
-	optlyClient, optlyContext, err := parseContext(r)
-	if err != nil {
-		RenderError(err, http.StatusInternalServerError, w, r)
-		return
-	}
-	experimentKey := chi.URLParam(r, "experimentKey")
-	if experimentKey == "" {
-		RenderError(errors.New("empty experimentKey"), http.StatusBadRequest, w, r)
-		return
-	}
-	variationKey := chi.URLParam(r, "variationKey")
-	if variationKey == "" {
-		RenderError(errors.New("empty variationKey"), http.StatusBadRequest, w, r)
-		return
-	}
-
-	wasSet, err := optlyClient.SetForcedVariation(experimentKey, optlyContext.UserContext.ID, variationKey)
-	switch {
-	case err != nil:
-		middleware.GetLogger(r).Error().Err(err).Msg("error setting forced variation")
-		RenderError(err, http.StatusInternalServerError, w, r)
-
-	case wasSet:
-		w.WriteHeader(http.StatusCreated)
-
-	default:
-		w.WriteHeader(http.StatusNoContent)
-	}
-}
-
-// RemoveForcedVariation - Remove a forced variation
-func (h *UserHandler) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
-	optlyClient, optlyContext, err := parseContext(r)
-	if err != nil {
-		RenderError(err, http.StatusInternalServerError, w, r)
-		return
-	}
-	experimentKey := chi.URLParam(r, "experimentKey")
-	if experimentKey == "" {
-		RenderError(errors.New("empty experimentKey"), http.StatusBadRequest, w, r)
-		return
-	}
-
-	err = optlyClient.RemoveForcedVariation(experimentKey, optlyContext.UserContext.ID)
-	if err != nil {
-		middleware.GetLogger(r).Error().Err(err).Msg("error removing forced variation")
-		RenderError(err, http.StatusInternalServerError, w, r)
-	} else {
-		w.WriteHeader(http.StatusNoContent)
-	}
 }
 
 // ListFeatures - List all feature decisions for a user

--- a/pkg/handlers/user_overrides.go
+++ b/pkg/handlers/user_overrides.go
@@ -1,0 +1,84 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/chi"
+
+	"github.com/optimizely/agent/pkg/middleware"
+)
+
+// UserOverrideHandler implements the UserAPI interface
+type UserOverrideHandler struct{}
+
+// SetForcedVariation - set a forced variation
+func (h *UserOverrideHandler) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
+	optlyClient, optlyContext, err := parseContext(r)
+	if err != nil {
+		RenderError(err, http.StatusInternalServerError, w, r)
+		return
+	}
+	experimentKey := chi.URLParam(r, "experimentKey")
+	if experimentKey == "" {
+		RenderError(errors.New("empty experimentKey"), http.StatusBadRequest, w, r)
+		return
+	}
+	variationKey := chi.URLParam(r, "variationKey")
+	if variationKey == "" {
+		RenderError(errors.New("empty variationKey"), http.StatusBadRequest, w, r)
+		return
+	}
+
+	wasSet, err := optlyClient.SetForcedVariation(experimentKey, optlyContext.UserContext.ID, variationKey)
+	switch {
+	case err != nil:
+		middleware.GetLogger(r).Error().Err(err).Msg("error setting forced variation")
+		RenderError(err, http.StatusInternalServerError, w, r)
+
+	case wasSet:
+		w.WriteHeader(http.StatusCreated)
+
+	default:
+		w.WriteHeader(http.StatusNoContent)
+	}
+}
+
+// RemoveForcedVariation - Remove a forced variation
+func (h *UserOverrideHandler) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
+	optlyClient, optlyContext, err := parseContext(r)
+	if err != nil {
+		RenderError(err, http.StatusInternalServerError, w, r)
+		return
+	}
+	experimentKey := chi.URLParam(r, "experimentKey")
+	if experimentKey == "" {
+		RenderError(errors.New("empty experimentKey"), http.StatusBadRequest, w, r)
+		return
+	}
+
+	err = optlyClient.RemoveForcedVariation(experimentKey, optlyContext.UserContext.ID)
+	if err != nil {
+		middleware.GetLogger(r).Error().Err(err).Msg("error removing forced variation")
+		RenderError(err, http.StatusInternalServerError, w, r)
+	} else {
+		w.WriteHeader(http.StatusNoContent)
+	}
+}

--- a/pkg/handlers/user_overrides.go
+++ b/pkg/handlers/user_overrides.go
@@ -26,6 +26,11 @@ import (
 	"github.com/optimizely/agent/pkg/middleware"
 )
 
+// Override defines the overrides to be applied.
+type Override struct {
+	VariationKey string `json:"variationKey"`
+}
+
 // UserOverrideHandler implements the UserAPI interface
 type UserOverrideHandler struct{}
 
@@ -41,13 +46,14 @@ func (h *UserOverrideHandler) SetForcedVariation(w http.ResponseWriter, r *http.
 		RenderError(errors.New("empty experimentKey"), http.StatusBadRequest, w, r)
 		return
 	}
-	variationKey := chi.URLParam(r, "variationKey")
-	if variationKey == "" {
+
+	override := &Override{}
+	if err = ParseRequestBody(r, override); err != nil {
 		RenderError(errors.New("empty variationKey"), http.StatusBadRequest, w, r)
 		return
 	}
 
-	wasSet, err := optlyClient.SetForcedVariation(experimentKey, optlyContext.UserContext.ID, variationKey)
+	wasSet, err := optlyClient.SetForcedVariation(experimentKey, optlyContext.UserContext.ID, override.VariationKey)
 	switch {
 	case err != nil:
 		middleware.GetLogger(r).Error().Err(err).Msg("error setting forced variation")

--- a/pkg/handlers/user_overrides_test.go
+++ b/pkg/handlers/user_overrides_test.go
@@ -1,0 +1,169 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/optimizely/go-sdk/pkg/decision"
+
+	"github.com/optimizely/agent/pkg/optimizely"
+	"github.com/optimizely/agent/pkg/optimizely/optimizelytest"
+
+	"github.com/go-chi/chi"
+	"github.com/optimizely/go-sdk/pkg/entities"
+	"github.com/stretchr/testify/suite"
+)
+
+type UserOverridesTestSuite struct {
+	suite.Suite
+	tc  *optimizelytest.TestClient
+	mux *chi.Mux
+}
+
+// Setup Mux
+func (suite *UserOverridesTestSuite) SetupTest() {
+	testClient := optimizelytest.NewClient()
+	optlyClient := &optimizely.OptlyClient{
+		OptimizelyClient: testClient.OptimizelyClient,
+		ConfigManager:    nil,
+		ForcedVariations: testClient.ForcedVariations,
+	}
+
+	mux := chi.NewMux()
+	userAPI := new(UserOverrideHandler)
+	userMW := &UserMW{optlyClient}
+
+	mux.Use(userMW.ClientCtx, userMW.UserCtx)
+	mux.Put("/experiments/{experimentKey}/variations/{variationKey}", userAPI.SetForcedVariation)
+	mux.Delete("/experiments/{experimentKey}/variations", userAPI.RemoveForcedVariation)
+
+	suite.mux = mux
+	suite.tc = testClient
+}
+
+func (suite *UserOverridesTestSuite) TestSetForcedVariation() {
+	feature := entities.Feature{Key: "my_feat"}
+	suite.tc.ProjectConfig.AddMultiVariationFeatureTest(feature, "variation_disabled", "variation_enabled")
+	featureExp := suite.tc.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
+
+	req := httptest.NewRequest("PUT", "/experiments/"+featureExp.Key+"/variations/variation_enabled", nil)
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusCreated, rec.Code)
+
+	key := decision.ExperimentOverrideKey{
+		ExperimentKey: featureExp.Key,
+		UserID:        "testUser",
+	}
+
+	actual, ok := suite.tc.ForcedVariations.GetVariation(key)
+	suite.True(ok)
+	suite.Equal("variation_enabled", actual)
+
+	req = httptest.NewRequest("PUT", "/experiments/"+featureExp.Key+"/variations/variation_enabled", nil)
+	rec = httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusNoContent, rec.Code)
+
+	actual, ok = suite.tc.ForcedVariations.GetVariation(key)
+	suite.True(ok)
+	suite.Equal("variation_enabled", actual)
+}
+
+func (suite *UserOverridesTestSuite) TestSetForcedVariationEmptyExperimentKey() {
+	req := httptest.NewRequest("PUT", "/experiments//variations/variation_enabled", nil)
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusBadRequest, rec.Code)
+}
+
+func (suite *UserOverridesTestSuite) TestRemoveForcedVariation() {
+	feature := entities.Feature{Key: "my_feat"}
+	suite.tc.ProjectConfig.AddMultiVariationFeatureTest(feature, "variation_disabled", "variation_enabled")
+	featureExp := suite.tc.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
+
+	suite.tc.ForcedVariations.SetVariation(decision.ExperimentOverrideKey{
+		ExperimentKey: featureExp.Key,
+		UserID:        "testUser",
+	}, "variation_enabled")
+
+	req := httptest.NewRequest("DELETE", "/experiments/"+featureExp.Key+"/variations", nil)
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusNoContent, rec.Code)
+
+	key := decision.ExperimentOverrideKey{
+		ExperimentKey: "my_feat",
+		UserID:        "testUser",
+	}
+
+	suite.Empty(suite.tc.ForcedVariations.GetVariation(key))
+}
+
+func (suite *UserOverridesTestSuite) TestRemoveForcedVariationEmptyExperimentKey() {
+	req := httptest.NewRequest("DELETE", "/experiments//variations", nil)
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusBadRequest, rec.Code)
+}
+
+// In order for 'go test' to run this suite, we need to create
+// a normal test function and pass our suite to suite.Run
+func TestUserOverrideTestSuite(t *testing.T) {
+	suite.Run(t, new(UserOverridesTestSuite))
+}
+
+func TestUserOverrideMissingClientCtx(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req := httptest.NewRequest("POST", "/", nil)
+
+	userOverrideHandler := new(UserOverrideHandler)
+	handlers := []func(w http.ResponseWriter, r *http.Request){
+		userOverrideHandler.SetForcedVariation,
+		userOverrideHandler.RemoveForcedVariation,
+	}
+
+	for _, handler := range handlers {
+		rec := httptest.NewRecorder()
+		http.HandlerFunc(handler).ServeHTTP(rec, req)
+		assertError(t, rec, "optlyClient not available", http.StatusInternalServerError)
+	}
+}
+
+func TestUserOverrideMissingOptlyCtx(t *testing.T) {
+	// Create a request to pass to our handler. We don't have any query parameters for now, so we'll
+	// pass 'nil' as the third parameter.
+	req := httptest.NewRequest("POST", "/", nil)
+	mw := new(UserMW)
+
+	userOverrideHandler := new(UserOverrideHandler)
+	handlers := []func(w http.ResponseWriter, r *http.Request){
+		userOverrideHandler.SetForcedVariation,
+		userOverrideHandler.RemoveForcedVariation,
+	}
+
+	for _, handler := range handlers {
+		rec := httptest.NewRecorder()
+		mw.ClientCtx(http.HandlerFunc(handler)).ServeHTTP(rec, req)
+		assertError(t, rec, "optlyContext not available", http.StatusInternalServerError)
+	}
+}

--- a/pkg/handlers/user_overrides_test.go
+++ b/pkg/handlers/user_overrides_test.go
@@ -24,13 +24,13 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/optimizely/go-sdk/pkg/decision"
-
 	"github.com/optimizely/agent/pkg/optimizely"
 	"github.com/optimizely/agent/pkg/optimizely/optimizelytest"
 
-	"github.com/go-chi/chi"
+	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/entities"
+
+	"github.com/go-chi/chi"
 	"github.com/stretchr/testify/suite"
 )
 

--- a/pkg/handlers/user_test.go
+++ b/pkg/handlers/user_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -24,8 +24,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-
-	"github.com/optimizely/go-sdk/pkg/decision"
 
 	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely"
@@ -115,8 +113,6 @@ func (suite *UserTestSuite) SetupTest() {
 
 	mux.With(userMW.ExperimentCtx).Get("/experiments/{experimentKey}", userAPI.GetVariation)
 	mux.With(userMW.ExperimentCtx).Post("/experiments/{experimentKey}", userAPI.ActivateExperiment)
-	mux.Put("/experiments/{experimentKey}/variations/{variationKey}", userAPI.SetForcedVariation)
-	mux.Delete("/experiments/{experimentKey}/variations", userAPI.RemoveForcedVariation)
 
 	suite.mux = mux
 	suite.tc = testClient
@@ -278,74 +274,6 @@ func (suite *UserTestSuite) TestTrackEventEmptyKey() {
 	suite.mux.ServeHTTP(rec, req)
 
 	suite.assertError(rec, "missing required path parameter: eventKey", http.StatusBadRequest)
-}
-
-func (suite *UserTestSuite) TestSetForcedVariation() {
-	feature := entities.Feature{Key: "my_feat"}
-	suite.tc.ProjectConfig.AddMultiVariationFeatureTest(feature, "variation_disabled", "variation_enabled")
-	featureExp := suite.tc.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
-
-	req := httptest.NewRequest("PUT", "/experiments/"+featureExp.Key+"/variations/variation_enabled", nil)
-	rec := httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusCreated, rec.Code)
-
-	req = httptest.NewRequest("GET", "/features/my_feat", nil)
-	rec = httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	var actual Feature
-	json.Unmarshal(rec.Body.Bytes(), &actual)
-	suite.True(actual.Enabled)
-
-	req = httptest.NewRequest("PUT", "/experiments/"+featureExp.Key+"/variations/variation_enabled", nil)
-	rec = httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusNoContent, rec.Code)
-
-	req = httptest.NewRequest("GET", "/features/my_feat", nil)
-	rec = httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	var actualRepeated Feature
-	json.Unmarshal(rec.Body.Bytes(), &actualRepeated)
-	suite.True(actualRepeated.Enabled)
-}
-
-func (suite *UserTestSuite) TestSetForcedVariationEmptyExperimentKey() {
-	req := httptest.NewRequest("PUT", "/experiments//variations/variation_enabled", nil)
-	rec := httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusBadRequest, rec.Code)
-}
-
-func (suite *UserTestSuite) TestRemoveForcedVariation() {
-	feature := entities.Feature{Key: "my_feat"}
-	suite.tc.ProjectConfig.AddMultiVariationFeatureTest(feature, "variation_disabled", "variation_enabled")
-	featureExp := suite.tc.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
-
-	suite.tc.ForcedVariations.SetVariation(decision.ExperimentOverrideKey{
-		ExperimentKey: featureExp.Key,
-		UserID:        "testUser",
-	}, "variation_enabled")
-
-	req := httptest.NewRequest("DELETE", "/experiments/"+featureExp.Key+"/variations", nil)
-	rec := httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusNoContent, rec.Code)
-
-	req = httptest.NewRequest("GET", "/features/my_feat", nil)
-	rec = httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusOK, rec.Code)
-	var actual Feature
-	json.Unmarshal(rec.Body.Bytes(), &actual)
-	suite.False(actual.Enabled)
-}
-
-func (suite *UserTestSuite) TestRemoveForcedVariationEmptyExperimentKey() {
-	req := httptest.NewRequest("DELETE", "/experiments//variations", nil)
-	rec := httptest.NewRecorder()
-	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusBadRequest, rec.Code)
 }
 
 func (suite *UserTestSuite) TestGetVariation() {
@@ -552,8 +480,6 @@ func TestUserMissingOptlyCtx(t *testing.T) {
 		userHandler.TrackFeature,
 		userHandler.TrackFeatures,
 		userHandler.TrackEvent,
-		userHandler.SetForcedVariation,
-		userHandler.RemoveForcedVariation,
 	}
 
 	for _, handler := range handlers {

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -111,8 +111,8 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 	r.Route("/overrides/users/{userID}", func(r chi.Router) {
 		r.Use(opt.middleware.ClientCtx, opt.middleware.UserCtx)
 
-		r.With(setForcedVariationTimer).Put("/experiments/{experimentKey}/variations/{variationKey}", opt.userOverrideAPI.SetForcedVariation)
-		r.With(removeForcedVariationTimer).Delete("/experiments/{experimentKey}/variations", opt.userOverrideAPI.RemoveForcedVariation)
+		r.With(setForcedVariationTimer).Put("/experiments/{experimentKey}", opt.userOverrideAPI.SetForcedVariation)
+		r.With(removeForcedVariationTimer).Delete("/experiments/{experimentKey}", opt.userOverrideAPI.RemoveForcedVariation)
 	})
 
 	return r

--- a/pkg/routers/api_test.go
+++ b/pkg/routers/api_test.go
@@ -287,7 +287,7 @@ func (suite *RouterTestSuite) TestActivateExperiment() {
 }
 
 func (suite *RouterTestSuite) TestSetForcedVariation() {
-	req := httptest.NewRequest("PUT", "/overrides/users/me/experiments/exp_key/variations/var_key", nil)
+	req := httptest.NewRequest("PUT", "/overrides/users/me/experiments/exp_key", nil)
 	rec := httptest.NewRecorder()
 
 	suite.mux.ServeHTTP(rec, req)
@@ -298,13 +298,12 @@ func (suite *RouterTestSuite) TestSetForcedVariation() {
 	expected := map[string]string{
 		"userID":        "me",
 		"experimentKey": "exp_key",
-		"variationKey":  "var_key",
 	}
 	suite.assertValid(rec, expected)
 }
 
 func (suite *RouterTestSuite) TestRemoveForcedVariation() {
-	req := httptest.NewRequest("DELETE", "/overrides/users/me/experiments/exp_key/variations", nil)
+	req := httptest.NewRequest("DELETE", "/overrides/users/me/experiments/exp_key", nil)
 	rec := httptest.NewRecorder()
 
 	suite.mux.ServeHTTP(rec, req)

--- a/pkg/routers/api_test.go
+++ b/pkg/routers/api_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019-2020, Optimizely, Inc. and contributors                        *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -87,12 +87,6 @@ func (m *MockFeatureAPI) GetFeature(w http.ResponseWriter, r *http.Request) {
 	renderPathParams(w, r)
 }
 
-type MockUserEventAPI struct{}
-
-func (m *MockUserEventAPI) AddUserEvent(w http.ResponseWriter, r *http.Request) {
-	renderPathParams(w, r)
-}
-
 type MockUserAPI struct{}
 
 func (m *MockUserAPI) TrackEvent(w http.ResponseWriter, r *http.Request) {
@@ -115,19 +109,21 @@ func (m *MockUserAPI) TrackFeatures(w http.ResponseWriter, r *http.Request) {
 	renderPathParams(w, r)
 }
 
-func (m *MockUserAPI) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
-	renderPathParams(w, r)
-}
-
-func (m *MockUserAPI) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
-	renderPathParams(w, r)
-}
-
 func (m *MockUserAPI) GetVariation(w http.ResponseWriter, r *http.Request) {
 	renderPathParams(w, r)
 }
 
 func (m *MockUserAPI) ActivateExperiment(w http.ResponseWriter, r *http.Request) {
+	renderPathParams(w, r)
+}
+
+type MockUserOverrideAPI struct{}
+
+func (m *MockUserOverrideAPI) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
+	renderPathParams(w, r)
+}
+
+func (m *MockUserOverrideAPI) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
 	renderPathParams(w, r)
 }
 
@@ -162,6 +158,7 @@ func (suite *RouterTestSuite) SetupTest() {
 		experimentAPI:   new(MockExperimentAPI),
 		featureAPI:      new(MockFeatureAPI),
 		userAPI:         new(MockUserAPI),
+		userOverrideAPI: new(MockUserOverrideAPI),
 		middleware:      new(MockOptlyMiddleware),
 		metricsRegistry: metricsRegistry,
 	}
@@ -290,7 +287,7 @@ func (suite *RouterTestSuite) TestActivateExperiment() {
 }
 
 func (suite *RouterTestSuite) TestSetForcedVariation() {
-	req := httptest.NewRequest("PUT", "/users/me/experiments/exp_key/variations/var_key", nil)
+	req := httptest.NewRequest("PUT", "/overrides/users/me/experiments/exp_key/variations/var_key", nil)
 	rec := httptest.NewRecorder()
 
 	suite.mux.ServeHTTP(rec, req)
@@ -307,7 +304,7 @@ func (suite *RouterTestSuite) TestSetForcedVariation() {
 }
 
 func (suite *RouterTestSuite) TestRemoveForcedVariation() {
-	req := httptest.NewRequest("DELETE", "/users/me/experiments/exp_key/variations", nil)
+	req := httptest.NewRequest("DELETE", "/overrides/users/me/experiments/exp_key/variations", nil)
 	rec := httptest.NewRecorder()
 
 	suite.mux.ServeHTTP(rec, req)


### PR DESCRIPTION
## Summary
* Moves user overrides into into own file and test file.
* Updates the method signture to use a request body as opposed to a URL param

After some discussion with @mjc1283 we decided to refactor the overrides API. This makes the API explicitly disjoint from the typical API usage by namespacing it under `/overrides`. We also changed the method signature to better reflect that only a single override can exist for a given experiment/user combo.