### PR TITLE
Add type coercion to user attributes. 

### DIFF
--- a/pkg/middleware/cached.go
+++ b/pkg/middleware/cached.go
@@ -87,7 +87,6 @@ func (mw *CachedOptlyMiddleware) ClientCtx(next http.Handler) http.Handler {
 // detail from a UPS or attribute store.
 func (mw *CachedOptlyMiddleware) UserCtx(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-
 		userID := chi.URLParam(r, "userID")
 		if userID == "" {
 			RenderError(fmt.Errorf("invalid request, missing userId"), http.StatusBadRequest, w, r)
@@ -95,18 +94,21 @@ func (mw *CachedOptlyMiddleware) UserCtx(next http.Handler) http.Handler {
 		}
 
 		// Remove userId and copy values into the attributes map
+		logger := GetLogger(r)
 		values := r.URL.Query()
 		attributes := make(map[string]interface{})
+
 		for k, v := range values {
 			// Assuming a single KV pair exists in the query parameters
-			attributes[k] = v[0]
-			GetLogger(r).Debug().Str("attrKey", k).Str("attrVal", v[0]).Msg("User attribute.")
+			val := v[0]
+			attributes[k] = CoerceType(val)
+			logger.Debug().Str("attrKey", k).Str("attrVal", val).Msg("User attribute.")
 		}
 
 		optlyContext := optimizely.NewContext(userID, attributes)
 		ctx := context.WithValue(r.Context(), OptlyContextKey, optlyContext)
 
-		GetLogger(r).Debug().Str("userId", userID).Msg("Adding user context to request.")
+		logger.Debug().Str("userId", userID).Msg("Adding user context to request.")
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})
 }
@@ -180,4 +182,3 @@ func (mw *CachedOptlyMiddleware) ExperimentCtx(next http.Handler) http.Handler {
 		RenderError(err, statusCode, w, r)
 	})
 }
-

--- a/pkg/middleware/cached_test.go
+++ b/pkg/middleware/cached_test.go
@@ -114,9 +114,10 @@ func (suite *OptlyMiddlewareTestSuite) TestGetClient() {
 
 func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 	attributes := map[string]interface{}{
-		"foo": "true",
-		"bar": "yes",
-		"baz": "100",
+		"bool":  true,
+		"str":   "yes",
+		"int":   int64(100),
+		"float": 1.00,
 	}
 	expected := optimizely.NewContext("test", attributes)
 
@@ -124,7 +125,7 @@ func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 	handler := AssertOptlyContextHandler(suite, expected)
 	mux.With(suite.mw.UserCtx).Get("/{userID}", handler)
 
-	req := httptest.NewRequest("GET", "/test?foo=true&bar=yes&baz=100", nil)
+	req := httptest.NewRequest("GET", "/test?bool=true&str=yes&baz=100&fiz=1.0", nil)
 	rec := httptest.NewRecorder()
 
 	mux.ServeHTTP(rec, req)

--- a/pkg/middleware/cached_test.go
+++ b/pkg/middleware/cached_test.go
@@ -114,10 +114,11 @@ func (suite *OptlyMiddlewareTestSuite) TestGetClient() {
 
 func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 	attributes := map[string]interface{}{
-		"bool":  true,
-		"str":   "yes",
-		"int":   int64(100),
-		"float": 1.00,
+		"bool":         true,
+		"str":          "yes",
+		"int":          int64(100),
+		"float":        1.00,
+		"quotedString": "true",
 	}
 	expected := optimizely.NewContext("test", attributes)
 
@@ -125,7 +126,7 @@ func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 	handler := AssertOptlyContextHandler(suite, expected)
 	mux.With(suite.mw.UserCtx).Get("/{userID}", handler)
 
-	req := httptest.NewRequest("GET", "/test?bool=true&str=yes&int=100&float=1.0", nil)
+	req := httptest.NewRequest("GET", `/test?bool=true&str=yes&int=100&float=1.0&quotedString="true"`, nil)
 	rec := httptest.NewRecorder()
 
 	mux.ServeHTTP(rec, req)

--- a/pkg/middleware/cached_test.go
+++ b/pkg/middleware/cached_test.go
@@ -125,7 +125,7 @@ func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 	handler := AssertOptlyContextHandler(suite, expected)
 	mux.With(suite.mw.UserCtx).Get("/{userID}", handler)
 
-	req := httptest.NewRequest("GET", "/test?bool=true&str=yes&baz=100&fiz=1.0", nil)
+	req := httptest.NewRequest("GET", "/test?bool=true&str=yes&int=100&float=1.0", nil)
 	rec := httptest.NewRecorder()
 
 	mux.ServeHTTP(rec, req)

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -105,8 +105,13 @@ func CoerceType(s string) interface{} {
 		return d
 	}
 
-	if b, err := strconv.ParseBool(s); err == nil {
-		return b
+	// Not using ParseBool since is support too many variants (e.g. 0, 1, FALSE, TRUE)
+	if s == "false" {
+		return false
+	}
+
+	if s == "true" {
+		return true
 	}
 
 	return s

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -88,7 +88,7 @@ func GetExperiment(r *http.Request) (*config.OptimizelyExperiment, error) {
 	return experiment, nil
 }
 
-// Coerce data type from string
+// CoerceType coerces typed value from string
 func CoerceType(s string) interface{} {
 	if i, err := strconv.ParseInt(s, 0, 64); err == nil {
 		return i

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -90,6 +90,13 @@ func GetExperiment(r *http.Request) (*config.OptimizelyExperiment, error) {
 
 // CoerceType coerces typed value from string
 func CoerceType(s string) interface{} {
+
+	if u, err := strconv.Unquote(s); err == nil {
+		if u != s {
+			return u
+		}
+	}
+
 	if i, err := strconv.ParseInt(s, 0, 64); err == nil {
 		return i
 	}

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -90,16 +90,16 @@ func GetExperiment(r *http.Request) (*config.OptimizelyExperiment, error) {
 
 // Coerce data type from string
 func CoerceType(s string) interface{} {
-	if b, err := strconv.ParseBool(s); err == nil {
-		return b
-	}
-
 	if i, err := strconv.ParseInt(s, 0, 64); err == nil {
 		return i
 	}
 
 	if d, err := strconv.ParseFloat(s, 64); err == nil {
 		return d
+	}
+
+	if b, err := strconv.ParseBool(s); err == nil {
+		return b
 	}
 
 	return s

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -97,7 +97,7 @@ func CoerceType(s string) interface{} {
 		}
 	}
 
-	if i, err := strconv.ParseInt(s, 0, 64); err == nil {
+	if i, err := strconv.ParseInt(s, 10, 0); err == nil {
 		return i
 	}
 

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -20,6 +20,7 @@ package middleware
 import (
 	"fmt"
 	"net/http"
+	"strconv"
 
 	"github.com/optimizely/agent/pkg/optimizely"
 
@@ -85,4 +86,21 @@ func GetExperiment(r *http.Request) (*config.OptimizelyExperiment, error) {
 		return nil, fmt.Errorf("experiment not available")
 	}
 	return experiment, nil
+}
+
+// Coerce data type from string
+func CoerceType(s string) interface{} {
+	if b, err := strconv.ParseBool(s); err == nil {
+		return b
+	}
+
+	if i, err := strconv.ParseInt(s, 0, 64); err == nil {
+		return i
+	}
+
+	if d, err := strconv.ParseFloat(s, 64); err == nil {
+		return d
+	}
+
+	return s
 }

--- a/pkg/middleware/utils_test.go
+++ b/pkg/middleware/utils_test.go
@@ -126,10 +126,26 @@ func TestCoerceType(t *testing.T) {
 	assert.Equal(t, true, CoerceType("True"))
 
 	assert.Equal(t, false, CoerceType("false"))
-	assert.Equal(t, false, CoerceType("false"))
+	assert.Equal(t, false, CoerceType("False"))
 
 	assert.Equal(t, 1.00, CoerceType("1.0"))
 	assert.Equal(t, 1.01, CoerceType("1.01"))
 
 	assert.Equal(t, "1.0a", CoerceType("1.0a"))
+}
+
+func TestCoerceTypeQuoted(t *testing.T) {
+	assert.Equal(t, "1", CoerceType(`"1"`))
+	assert.Equal(t, "10", CoerceType(`"10"`))
+
+	assert.Equal(t, "true", CoerceType(`"true"`))
+	assert.Equal(t, "True", CoerceType(`"True"`))
+
+	assert.Equal(t, "false", CoerceType(`"false"`))
+	assert.Equal(t, "False", CoerceType(`"False"`))
+
+	assert.Equal(t, "1.0", CoerceType(`"1.0"`))
+	assert.Equal(t, "1.01", CoerceType(`"1.01"`))
+
+	assert.Equal(t, "1.0a", CoerceType(`"1.0a"`))
 }

--- a/pkg/middleware/utils_test.go
+++ b/pkg/middleware/utils_test.go
@@ -123,15 +123,14 @@ func TestCoerceType(t *testing.T) {
 	assert.Equal(t, int64(10), CoerceType("10"))
 
 	assert.Equal(t, true, CoerceType("true"))
-	assert.Equal(t, true, CoerceType("True"))
-
 	assert.Equal(t, false, CoerceType("false"))
-	assert.Equal(t, false, CoerceType("False"))
 
 	assert.Equal(t, 1.00, CoerceType("1.0"))
 	assert.Equal(t, 1.01, CoerceType("1.01"))
 
 	assert.Equal(t, "1.0a", CoerceType("1.0a"))
+	assert.Equal(t, "True", CoerceType("True"))
+	assert.Equal(t, "False", CoerceType("False"))
 }
 
 func TestCoerceTypeQuoted(t *testing.T) {
@@ -139,13 +138,12 @@ func TestCoerceTypeQuoted(t *testing.T) {
 	assert.Equal(t, "10", CoerceType(`"10"`))
 
 	assert.Equal(t, "true", CoerceType(`"true"`))
-	assert.Equal(t, "True", CoerceType(`"True"`))
-
 	assert.Equal(t, "false", CoerceType(`"false"`))
-	assert.Equal(t, "False", CoerceType(`"False"`))
 
 	assert.Equal(t, "1.0", CoerceType(`"1.0"`))
 	assert.Equal(t, "1.01", CoerceType(`"1.01"`))
 
 	assert.Equal(t, "1.0a", CoerceType(`"1.0a"`))
+	assert.Equal(t, "True", CoerceType(`"True"`))
+	assert.Equal(t, "False", CoerceType(`"False"`))
 }

--- a/pkg/middleware/utils_test.go
+++ b/pkg/middleware/utils_test.go
@@ -117,3 +117,19 @@ func TestGetExperimentNotSet(t *testing.T) {
 	assert.Nil(t, actual)
 	assert.Error(t, err)
 }
+
+func TestCoerceType(t *testing.T) {
+	assert.Equal(t, int64(1), CoerceType("1"))
+	assert.Equal(t, int64(10), CoerceType("10"))
+
+	assert.Equal(t, true, CoerceType("true"))
+	assert.Equal(t, true, CoerceType("True"))
+
+	assert.Equal(t, false, CoerceType("false"))
+	assert.Equal(t, false, CoerceType("false"))
+
+	assert.Equal(t, 1.00, CoerceType("1.0"))
+	assert.Equal(t, 1.01, CoerceType("1.01"))
+
+	assert.Equal(t, "1.0a", CoerceType("1.0a"))
+}


### PR DESCRIPTION
## Summary
* Coerce user attributes to support data types
* Update tests to match coerced values

This change fixes a compatibility gap where all user attribute values were being handled as strings. Values are now coerced into typed values when applicable. Note that this will require some documentation on how values are coerced since this is unique to Agent.

Note that strings can be forced if quoted in the URL params.