### PR TITLE
Refactor configuration struct and add /config endpoint.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,17 +72,21 @@ Below is a comprehensive list of available configuration properties.
 
 |Property Name|Env Variable|Description|
 |---|---|---|
+|author|OPTIMIZELY_AUTHOR|Agent author. Default: Optimizely Inc.|
+|name|OPTIMIZELY_NAME|Agent name. Default: optimizely|
+|version|OPTIMIZELY_VERSION|Agent version. Default: `git describe --tags`|
 |config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
 |log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|
 |log.pretty|OPTIMIZELY_LOG_PRETTY|Flag used to set colorized console output as opposed to structured json logs. Default: false|
 |server.readtimeout|OPTIMIZELY_SERVER_READTIMEOUT|The maximum duration for reading the entire body. Default: “5s”|
 |server.writetimeout|OPTIMIZELY_SERVER_WRITETIMEOUT|The maximum duration before timing out writes of the response. Default: “10s”|
-|admin.author|OPTIMIZELY_ADMIN_AUTHOR|Agent version. Default: Optimizely Inc.|
-|admin.name|OPTIMIZELY_ADMIN_NAME|Agent name. Default: optimizely|
 |admin.port|OPTIMIZELY_ADMIN_PORT|Admin listener port. Default: 8088|
-|admin.version|OPTIMIZELY_ADMIN_VERSION|Agent version. Default: `git describe --tags`|
 |api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
 |api.maxconns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
+|optly.sdkkeys|OPTIMIZELY_OPTLY_SDK_KEYS|List of SDK keys used to initialize on startup|
+|optly.processor.batchSize|OPTIMIZELY_OPTLY_PROCESSOR_BATCHSIZE|The number of events in a batch. Default: 10|
+|optly.processor.queueSize|OPTIMIZELY_OPTLY_PROCESSOR_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
+|optly.processor.flushInterval|OPTIMIZELY_OPTLY_PROCESSOR_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
 |webhook.port|OPTIMIZELY_WEBHOOK_PORT|Webhook listener port: Default: 8085|
 |webhook.projects.<*projectId*>.sdkKeys|N/A|Comma delimited list of SDK Keys applicable to the respective projectId|
 |webhook.projects.<*projectId*>.secret|N/A|Webhook secret used to validate webhook requests originating from the respective projectId|

--- a/README.md
+++ b/README.md
@@ -72,10 +72,14 @@ Below is a comprehensive list of available configuration properties.
 
 |Property Name|Env Variable|Description|
 |---|---|---|
+|config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
 |author|OPTIMIZELY_AUTHOR|Agent author. Default: Optimizely Inc.|
 |name|OPTIMIZELY_NAME|Agent name. Default: optimizely|
 |version|OPTIMIZELY_VERSION|Agent version. Default: `git describe --tags`|
-|config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
+|sdkkeys|OPTIMIZELY_SDK_KEYS|List of SDK keys used to initialize on startup|
+|processor.batchSize|OPTIMIZELY_PROCESSOR_BATCHSIZE|The number of events in a batch. Default: 10|
+|processor.queueSize|OPTIMIZELY_PROCESSOR_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
+|processor.flushInterval|OPTIMIZELY_PROCESSOR_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
 |log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|
 |log.pretty|OPTIMIZELY_LOG_PRETTY|Flag used to set colorized console output as opposed to structured json logs. Default: false|
 |server.readtimeout|OPTIMIZELY_SERVER_READTIMEOUT|The maximum duration for reading the entire body. Default: “5s”|
@@ -83,10 +87,6 @@ Below is a comprehensive list of available configuration properties.
 |admin.port|OPTIMIZELY_ADMIN_PORT|Admin listener port. Default: 8088|
 |api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
 |api.maxconns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
-|optly.sdkkeys|OPTIMIZELY_OPTLY_SDK_KEYS|List of SDK keys used to initialize on startup|
-|optly.processor.batchSize|OPTIMIZELY_OPTLY_PROCESSOR_BATCHSIZE|The number of events in a batch. Default: 10|
-|optly.processor.queueSize|OPTIMIZELY_OPTLY_PROCESSOR_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
-|optly.processor.flushInterval|OPTIMIZELY_OPTLY_PROCESSOR_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
 |webhook.port|OPTIMIZELY_WEBHOOK_PORT|Webhook listener port: Default: 8085|
 |webhook.projects.<*projectId*>.sdkKeys|N/A|Comma delimited list of SDK Keys applicable to the respective projectId|
 |webhook.projects.<*projectId*>.secret|N/A|Webhook secret used to validate webhook requests originating from the respective projectId|

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,7 +104,8 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background()) // Create default service context
 	sg := server.NewGroup(ctx, conf.Server)                 // Create a new server group to manage the individual http listeners
-	optlyCache := optimizely.NewCache(ctx, conf.SDKKeys, sdkMetricsRegistry)
+	optlyCache := optimizely.NewCache(ctx, conf.Processor, sdkMetricsRegistry)
+	optlyCache.Init(conf.SDKKeys)
 
 	// goroutine to check for signals to gracefully shutdown listeners
 	go func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background()) // Create default service context
 	sg := server.NewGroup(ctx, conf.Server)                 // Create a new server group to manage the individual http listeners
-	optlyCache := optimizely.NewCache(ctx, conf.Optly, sdkMetricsRegistry)
+	optlyCache := optimizely.NewCache(ctx, conf.SDKKeys, sdkMetricsRegistry)
 
 	// goroutine to check for signals to gracefully shutdown listeners
 	go func() {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -46,7 +46,7 @@ func initConfig(v *viper.Viper) error {
 	// Load defaults from the AgentConfig by loading the marshaled values as yaml
 	// https://github.com/spf13/viper/issues/188
 	defaultConf := config.NewDefaultConfig()
-	defaultConf.Admin.Version = Version
+	defaultConf.Version = Version
 	b, err := yaml.Marshal(defaultConf)
 	if err != nil {
 		return err
@@ -117,10 +117,10 @@ func main() {
 		cancel()
 	}()
 
-	log.Info().Str("version", conf.Admin.Version).Msg("Starting services.")
+	log.Info().Str("version", conf.Version).Msg("Starting services.")
 	sg.GoListenAndServe("api", conf.API.Port, routers.NewDefaultAPIRouter(optlyCache, conf.API, agentMetricsRegistry))
 	sg.GoListenAndServe("webhook", conf.Webhook.Port, routers.NewWebhookRouter(optlyCache, conf.Webhook))
-	sg.GoListenAndServe("admin", conf.Admin.Port, routers.NewAdminRouter(conf.Admin)) // Admin should be added last.
+	sg.GoListenAndServe("admin", conf.Admin.Port, routers.NewAdminRouter(*conf)) // Admin should be added last.
 
 	// wait for server group to shutdown
 	if err := sg.Wait(); err == nil {

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -27,6 +27,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func assertRoot(t *testing.T, actual *config.AgentConfig) {
+	assert.Equal(t, "0.1.0", actual.Version)
+	assert.Equal(t, "Optimizely Inc.", actual.Author)
+	assert.Equal(t, "optimizely", actual.Name)
+}
+
 func assertServer(t *testing.T, actual config.ServerConfig) {
 	assert.Equal(t, 5*time.Second, actual.ReadTimeout)
 	assert.Equal(t, 10*time.Second, actual.WriteTimeout)
@@ -39,9 +45,6 @@ func assertLog(t *testing.T, actual config.LogConfig) {
 
 func assertAdmin(t *testing.T, actual config.AdminConfig) {
 	assert.Equal(t, "3002", actual.Port)
-	assert.Equal(t, "0.1.0", actual.Version)
-	assert.Equal(t, "Optimizely Inc.", actual.Author)
-	assert.Equal(t, "optimizely", actual.Name)
 }
 
 func assertAPI(t *testing.T, actual config.APIConfig) {
@@ -69,6 +72,7 @@ func TestViperYaml(t *testing.T) {
 
 	actual := loadConfig(v)
 
+	assertRoot(t, actual)
 	assertServer(t, actual.Server)
 	assertLog(t, actual.Log)
 	assertAdmin(t, actual.Admin)
@@ -80,6 +84,10 @@ func TestViperYaml(t *testing.T) {
 func TestViperProps(t *testing.T) {
 	v := viper.New()
 
+	v.Set("version", "0.1.0")
+	v.Set("author", "Optimizely Inc.")
+	v.Set("name", "optimizely")
+
 	v.Set("server.readtimeout", 5*time.Second)
 	v.Set("server.writetimeout", 10*time.Second)
 
@@ -87,9 +95,6 @@ func TestViperProps(t *testing.T) {
 	v.Set("log.level", "debug")
 
 	v.Set("admin.port", "3002")
-	v.Set("admin.version", "0.1.0")
-	v.Set("admin.author", "Optimizely Inc.")
-	v.Set("admin.name", "optimizely")
 
 	v.Set("api.maxconns", 100)
 	v.Set("api.port", "3000")
@@ -107,6 +112,7 @@ func TestViperProps(t *testing.T) {
 	assert.NoError(t, initConfig(v))
 	actual := loadConfig(v)
 
+	assertRoot(t, actual)
 	assertServer(t, actual.Server)
 	assertLog(t, actual.Log)
 	assertAdmin(t, actual.Admin)
@@ -116,6 +122,10 @@ func TestViperProps(t *testing.T) {
 }
 
 func TestViperEnv(t *testing.T) {
+	_ = os.Setenv("OPTIMIZELY_VERSION", "0.1.0")
+	_ = os.Setenv("OPTIMIZELY_AUTHOR", "Optimizely Inc.")
+	_ = os.Setenv("OPTIMIZELY_NAME", "optimizely")
+
 	_ = os.Setenv("OPTIMIZELY_SERVER_READTIMEOUT", "5s")
 	_ = os.Setenv("OPTIMIZELY_SERVER_WRITETIMEOUT", "10s")
 
@@ -123,9 +133,6 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_LOG_LEVEL", "debug")
 
 	_ = os.Setenv("OPTIMIZELY_ADMIN_PORT", "3002")
-	_ = os.Setenv("OPTIMIZELY_ADMIN_VERSION", "0.1.0")
-	_ = os.Setenv("OPTIMIZELY_ADMIN_AUTHOR", "Optimizely Inc.")
-	_ = os.Setenv("OPTIMIZELY_ADMIN_NAME", "optimizely")
 
 	_ = os.Setenv("OPTIMIZELY_API_MAXCONNS", "100")
 	_ = os.Setenv("OPTIMIZELY_API_PORT", "3000")
@@ -144,6 +151,7 @@ func TestViperEnv(t *testing.T) {
 	assert.NoError(t, initConfig(v))
 	actual := loadConfig(v)
 
+	assertRoot(t, actual)
 	assertServer(t, actual.Server)
 	assertLog(t, actual.Log)
 	assertAdmin(t, actual.Admin)

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -31,6 +31,7 @@ func assertRoot(t *testing.T, actual *config.AgentConfig) {
 	assert.Equal(t, "0.1.0", actual.Version)
 	assert.Equal(t, "Optimizely Inc.", actual.Author)
 	assert.Equal(t, "optimizely", actual.Name)
+	assert.Equal(t, []string{"ddd", "eee", "fff"}, actual.SDKKeys)
 }
 
 func assertServer(t *testing.T, actual config.ServerConfig) {
@@ -62,10 +63,6 @@ func assertWebhook(t *testing.T, actual config.WebhookConfig) {
 	assert.False(t, actual.Projects[20000].SkipSignatureCheck)
 }
 
-func assertOptly(t *testing.T, actual config.OptlyConfig) {
-	assert.Equal(t, []string{"ddd", "eee", "fff"}, actual.SDKKeys)
-}
-
 func TestViperYaml(t *testing.T) {
 	v := viper.New()
 	v.Set("config.filename", "./testdata/default.yaml")
@@ -78,7 +75,6 @@ func TestViperYaml(t *testing.T) {
 	assertAdmin(t, actual.Admin)
 	assertAPI(t, actual.API)
 	assertWebhook(t, actual.Webhook)
-	assertOptly(t, actual.Optly)
 }
 
 func TestViperProps(t *testing.T) {
@@ -87,6 +83,7 @@ func TestViperProps(t *testing.T) {
 	v.Set("version", "0.1.0")
 	v.Set("author", "Optimizely Inc.")
 	v.Set("name", "optimizely")
+	v.Set("sdkkeys", []string{"ddd", "eee", "fff"})
 
 	v.Set("server.readtimeout", 5*time.Second)
 	v.Set("server.writetimeout", 10*time.Second)
@@ -107,8 +104,6 @@ func TestViperProps(t *testing.T) {
 	v.Set("webhook.projects.20000.sdkkeys", []string{"xxx", "yyy", "zzz"})
 	v.Set("webhook.projects.20000.skipsignaturecheck", false)
 
-	v.Set("optly.sdkkeys", []string{"ddd", "eee", "fff"})
-
 	assert.NoError(t, initConfig(v))
 	actual := loadConfig(v)
 
@@ -118,13 +113,13 @@ func TestViperProps(t *testing.T) {
 	assertAdmin(t, actual.Admin)
 	assertAPI(t, actual.API)
 	assertWebhook(t, actual.Webhook)
-	assertOptly(t, actual.Optly)
 }
 
 func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_VERSION", "0.1.0")
 	_ = os.Setenv("OPTIMIZELY_AUTHOR", "Optimizely Inc.")
 	_ = os.Setenv("OPTIMIZELY_NAME", "optimizely")
+	_ = os.Setenv("OPTIMIZELY_SDKKEYS", "ddd,eee,fff")
 
 	_ = os.Setenv("OPTIMIZELY_SERVER_READTIMEOUT", "5s")
 	_ = os.Setenv("OPTIMIZELY_SERVER_WRITETIMEOUT", "10s")
@@ -145,8 +140,6 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_WEBHOOK_PROJECTS_20000_SDKKEYS", "xxx,yyy,zzz")
 	_ = os.Setenv("OPTIMIZELY_WEBHOOK_PROJECTS_20000_SKIPSIGNATURECHECK", "false")
 
-	_ = os.Setenv("OPTIMIZELY_OPTLY_SDKKEYS", "ddd,eee,fff")
-
 	v := viper.New()
 	assert.NoError(t, initConfig(v))
 	actual := loadConfig(v)
@@ -157,5 +150,4 @@ func TestViperEnv(t *testing.T) {
 	assertAdmin(t, actual.Admin)
 	assertAPI(t, actual.API)
 	//assertWebhook(t, actual.Webhook) // Maps don't appear to be supported
-	assertOptly(t, actual.Optly)
 }

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -1,6 +1,10 @@
 version: 0.1.0
 author: Optimizely Inc.
 name: optimizely
+sdkkeys:
+  - ddd
+  - eee
+  - fff
 server:
   readTimeout: 5s
   writeTimeout: 10s
@@ -28,8 +32,3 @@ webhook:
         - yyy
         - zzz
       secret: secret-20000
-optly:
-  sdkkeys:
-    - ddd
-    - eee
-    - fff

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -1,3 +1,6 @@
+version: 0.1.0
+author: Optimizely Inc.
+name: optimizely
 server:
   readTimeout: 5s
   writeTimeout: 10s
@@ -5,17 +8,11 @@ log:
   pretty: true
   level: debug
 admin:
-  enabled: false
-  version: 0.1.0
-  author: Optimizely Inc.
-  name: optimizely
   port: "3002"
 api:
-  enabled: true
   maxconns: 100
   port: "3000"
 webhook:
-  enabled: true
   port: "3001"
   projects:
     10000:

--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ server:
 ##
 api:
     ## the maximum number of concurrent requests handled by the api listener
-    maxconns: 100
+#    maxconns: 10000
     ## http listener port
     port: "8080"
 

--- a/config.yaml
+++ b/config.yaml
@@ -6,7 +6,12 @@ author: "Optimizely Inc."
 name: "optimizely"
 ## version of the application included in the /info response and startup logs
 ## Defaults to the latest git tag `git describe --tags`
-#    version: custom-build
+#version: custom-build
+
+## list of SDK keys to be pre-fetched during startup (recommended for production)
+#sdkkeys:
+#    - <sdk-key-1>
+#    - <sdk-key-2>
 
 ##
 ## log: logger configuration
@@ -67,18 +72,12 @@ webhook:
 #            skipSignatureCheck: true
 
 ##
-## optly (short for optimizely) configs are passed used to configure the underlying SDK instance
+## event processor configurations
 ##
-opyly:
-#    ## list of SDK keys to be pre-fetched during startup (recommended for production)
-#    sdkkeys:
-#        - <sdk-key-1>
-#        - <sdk-key-2>
-    ## event processor configurations
-    processor:
-        ## the number of events in a batch
-        batchSize: 10
-        ## the max number of events pending dispatch, setting this too low may result in events being dropped
-        queueSize: 1000
-        ## the maximum time between events being dispatched
-        flushInterval: 30s
+processor:
+    ## the number of events in a batch
+    batchSize: 10
+    ## the max number of events pending dispatch, setting this too low may result in events being dropped
+    queueSize: 1000
+    ## the maximum time between events being dispatched
+    flushInterval: 30s

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,13 @@
 ## config.yaml provides a default set of configuration options
 
+## service author included in the /info response
+author: "Optimizely Inc."
+## name of the running application included in the /info response
+name: "optimizely"
+## version of the application included in the /info response and startup logs
+## Defaults to the latest git tag `git describe --tags`
+#    version: custom-build
+
 ##
 ## log: logger configuration
 ##
@@ -35,13 +43,6 @@ api:
 ## admin service configuration
 ##
 admin:
-    ## service author included in the /info response
-    author: "Optimizely Inc."
-    ## name of the running application included in the /info response
-    name: "optimizely"
-#    ## version of the application included in the /info response and startup logs
-#    ## Defaults to the latest git tag `git describe --tags`
-#    version: custom-build
     ## http listener port
     port: "8088"
 
@@ -64,3 +65,20 @@ webhook:
 #            secret: <secret-10000>
 #            ## skipSignatureCheck: override the signature check (not recommended for production)
 #            skipSignatureCheck: true
+
+##
+## optly (short for optimizely) configs are passed used to configure the underlying SDK instance
+##
+opyly:
+#    ## list of SDK keys to be pre-fetched during startup (recommended for production)
+#    sdkkeys:
+#        - <sdk-key-1>
+#        - <sdk-key-2>
+    ## event processor configurations
+    processor:
+        ## the number of events in a batch
+        batchSize: 10
+        ## the size of the buffered queue, setting this too low may result in events being dropped
+        queueSize: 1000
+        ## the maximum time between events being dispatched
+        flushInterval: 30s

--- a/config.yaml
+++ b/config.yaml
@@ -78,7 +78,7 @@ opyly:
     processor:
         ## the number of events in a batch
         batchSize: 10
-        ## the size of the buffered queue, setting this too low may result in events being dropped
+        ## the max number of events pending dispatch, setting this too low may result in events being dropped
         queueSize: 1000
         ## the maximum time between events being dispatched
         flushInterval: 30s

--- a/config/config.go
+++ b/config/config.go
@@ -40,12 +40,10 @@ func NewDefaultConfig() *AgentConfig {
 			Pretty: false,
 			Level:  "info",
 		},
-		Optly: OptlyConfig{
-			Processor: ProcessorConfig{
-				BatchSize:     10,
-				QueueSize:     1000,
-				FlushInterval: 30 * time.Second,
-			},
+		Processor: ProcessorConfig{
+			BatchSize:     10,
+			QueueSize:     1000,
+			FlushInterval: 30 * time.Second,
 		},
 		Server: ServerConfig{
 			ReadTimeout:  5 * time.Second,
@@ -65,18 +63,19 @@ type AgentConfig struct {
 	Author  string `yaml:"author" json:"author"`
 	Name    string `yaml:"name" json:"name"`
 
-	Admin   AdminConfig   `yaml:"admin" json:"admin"`
-	API     APIConfig     `yaml:"api" json:"api"`
-	Log     LogConfig     `yaml:"log" json:"log"`
-	Optly   OptlyConfig   `yaml:"optly" json:"optly"`
-	Server  ServerConfig  `yaml:"server" json:"server"`
-	Webhook WebhookConfig `yaml:"webhook" json:"webhook"`
+	SDKKeys []string `yaml:"sdkkeys" json:"sdkkeys"`
+
+	Admin     AdminConfig     `yaml:"admin" json:"admin"`
+	API       APIConfig       `yaml:"api" json:"api"`
+	Log       LogConfig       `yaml:"log" json:"log"`
+	Processor ProcessorConfig `yaml:"processor" json:"processor"`
+	Server    ServerConfig    `yaml:"server" json:"server"`
+	Webhook   WebhookConfig   `yaml:"webhook" json:"webhook"`
 }
 
 // OptlyConfig holds the set of SDK keys to bootstrap during initialization
 type OptlyConfig struct {
 	Processor ProcessorConfig `yaml:"processor" json:"processor"`
-	SDKKeys   []string        `yaml:"sdkkeys" json:"sdkkeys"`
 }
 
 // ProcessorConfig holds the configuration options for the Optimizely Event Processor.

--- a/config/config.go
+++ b/config/config.go
@@ -25,11 +25,12 @@ import (
 func NewDefaultConfig() *AgentConfig {
 
 	config := AgentConfig{
+		Version: "",
+		Author:  "Optimizely Inc.",
+		Name:    "optimizely",
+
 		Admin: AdminConfig{
-			Version: "",
-			Author:  "Optimizely Inc.",
-			Name:    "optimizely",
-			Port:    "8088",
+			Port: "8088",
 		},
 		API: APIConfig{
 			MaxConns: 0,
@@ -60,62 +61,63 @@ func NewDefaultConfig() *AgentConfig {
 
 // AgentConfig is the top level configuration struct
 type AgentConfig struct {
-	Admin   AdminConfig   `yaml:"admin"`
-	API     APIConfig     `yaml:"api"`
-	Log     LogConfig     `yaml:"log"`
-	Optly   OptlyConfig   `yaml:"optly"`
-	Server  ServerConfig  `yaml:"server"`
-	Webhook WebhookConfig `yaml:"webhook"`
+	Version string `yaml:"version" json:"version"`
+	Author  string `yaml:"author" json:"author"`
+	Name    string `yaml:"name" json:"name"`
+
+	Admin   AdminConfig   `yaml:"admin" json:"admin"`
+	API     APIConfig     `yaml:"api" json:"api"`
+	Log     LogConfig     `yaml:"log" json:"log"`
+	Optly   OptlyConfig   `yaml:"optly" json:"optly"`
+	Server  ServerConfig  `yaml:"server" json:"server"`
+	Webhook WebhookConfig `yaml:"webhook" json:"webhook"`
 }
 
 // OptlyConfig holds the set of SDK keys to bootstrap during initialization
 type OptlyConfig struct {
-	Processor ProcessorConfig `yaml:"processor"`
-	SDKKeys   []string        `yaml:"sdkkeys"`
+	Processor ProcessorConfig `yaml:"processor" json:"processor"`
+	SDKKeys   []string        `yaml:"sdkkeys" json:"sdkkeys"`
 }
 
 // ProcessorConfig holds the configuration options for the Optimizely Event Processor.
 type ProcessorConfig struct {
-	BatchSize     int           `yaml:"batchSize" default:"10"`
-	QueueSize     int           `yaml:"queueSize" default:"1000"`
-	FlushInterval time.Duration `yaml:"flushInterval" default:"30s"`
+	BatchSize     int           `yaml:"batchSize" json:"batchSize" default:"10"`
+	QueueSize     int           `yaml:"queueSize" json:"queueSize" default:"1000"`
+	FlushInterval time.Duration `yaml:"flushInterval" json:"flushInterval" default:"30s"`
 }
 
 // LogConfig holds the log configuration
 type LogConfig struct {
-	Pretty bool   `yaml:"pretty"`
-	Level  string `yaml:"level"`
+	Pretty bool   `yaml:"pretty" json:"pretty"`
+	Level  string `yaml:"level" json:"level"`
 }
 
 // ServerConfig holds the global http server configs
 type ServerConfig struct {
-	ReadTimeout  time.Duration `yaml:"readtimeout"`
-	WriteTimeout time.Duration `yaml:"writetimeout"`
+	ReadTimeout  time.Duration `yaml:"readtimeout" json:"readtimeout"`
+	WriteTimeout time.Duration `yaml:"writetimeout" json:"writetimeout"`
 }
 
 // APIConfig holds the REST API configuration
 type APIConfig struct {
-	MaxConns int    `yaml:"maxconns"`
-	Port     string `yaml:"port"`
+	MaxConns int    `yaml:"maxconns" json:"maxconns"`
+	Port     string `yaml:"port" json:"port"`
 }
 
 // AdminConfig holds the configuration for the admin web interface
 type AdminConfig struct {
-	Version string `yaml:"version"`
-	Author  string `yaml:"author"`
-	Name    string `yaml:"name"`
-	Port    string `yaml:"port"`
+	Port string `yaml:"port" json:"port"`
 }
 
 // WebhookConfig holds configuration for Optimizely Webhooks
 type WebhookConfig struct {
-	Port     string                   `yaml:"port"`
-	Projects map[int64]WebhookProject `mapstructure:"projects"`
+	Port     string                   `yaml:"port" json:"port"`
+	Projects map[int64]WebhookProject `mapstructure:"projects" json:"projects"`
 }
 
 // WebhookProject holds the configuration for a single Project webhook
 type WebhookProject struct {
-	SDKKeys            []string `yaml:"sdkKeys"`
-	Secret             string   `yaml:"secret"`
-	SkipSignatureCheck bool     `yaml:"skipSignatureCheck" default:"false"`
+	SDKKeys            []string `yaml:"sdkKeys" json:"sdkKeys"`
+	Secret             string   `yaml:"secret" json:"-"`
+	SkipSignatureCheck bool     `yaml:"skipSignatureCheck" json:"skipSignatureCheck" default:"false"`
 }

--- a/config/config.go
+++ b/config/config.go
@@ -59,64 +59,59 @@ func NewDefaultConfig() *AgentConfig {
 
 // AgentConfig is the top level configuration struct
 type AgentConfig struct {
-	Version string `yaml:"version" json:"version"`
-	Author  string `yaml:"author" json:"author"`
-	Name    string `yaml:"name" json:"name"`
+	Version string `json:"version"`
+	Author  string `json:"author"`
+	Name    string `json:"name"`
 
 	SDKKeys []string `yaml:"sdkkeys" json:"sdkkeys"`
 
-	Admin     AdminConfig     `yaml:"admin" json:"admin"`
-	API       APIConfig       `yaml:"api" json:"api"`
-	Log       LogConfig       `yaml:"log" json:"log"`
-	Processor ProcessorConfig `yaml:"processor" json:"processor"`
-	Server    ServerConfig    `yaml:"server" json:"server"`
-	Webhook   WebhookConfig   `yaml:"webhook" json:"webhook"`
-}
-
-// OptlyConfig holds the set of SDK keys to bootstrap during initialization
-type OptlyConfig struct {
-	Processor ProcessorConfig `yaml:"processor" json:"processor"`
+	Admin     AdminConfig     `json:"admin"`
+	API       APIConfig       `json:"api"`
+	Log       LogConfig       `json:"log"`
+	Processor ProcessorConfig `json:"processor"`
+	Server    ServerConfig    `json:"server"`
+	Webhook   WebhookConfig   `json:"webhook"`
 }
 
 // ProcessorConfig holds the configuration options for the Optimizely Event Processor.
 type ProcessorConfig struct {
-	BatchSize     int           `yaml:"batchSize" json:"batchSize" default:"10"`
-	QueueSize     int           `yaml:"queueSize" json:"queueSize" default:"1000"`
-	FlushInterval time.Duration `yaml:"flushInterval" json:"flushInterval" default:"30s"`
+	BatchSize     int           `json:"batchSize" default:"10"`
+	QueueSize     int           `json:"queueSize" default:"1000"`
+	FlushInterval time.Duration `json:"flushInterval" default:"30s"`
 }
 
 // LogConfig holds the log configuration
 type LogConfig struct {
-	Pretty bool   `yaml:"pretty" json:"pretty"`
-	Level  string `yaml:"level" json:"level"`
+	Pretty bool   `json:"pretty"`
+	Level  string `json:"level"`
 }
 
 // ServerConfig holds the global http server configs
 type ServerConfig struct {
-	ReadTimeout  time.Duration `yaml:"readtimeout" json:"readtimeout"`
-	WriteTimeout time.Duration `yaml:"writetimeout" json:"writetimeout"`
+	ReadTimeout  time.Duration `json:"readtimeout"`
+	WriteTimeout time.Duration `json:"writetimeout"`
 }
 
 // APIConfig holds the REST API configuration
 type APIConfig struct {
-	MaxConns int    `yaml:"maxconns" json:"maxconns"`
-	Port     string `yaml:"port" json:"port"`
+	MaxConns int    `json:"maxconns"`
+	Port     string `json:"port"`
 }
 
 // AdminConfig holds the configuration for the admin web interface
 type AdminConfig struct {
-	Port string `yaml:"port" json:"port"`
+	Port string `json:"port"`
 }
 
 // WebhookConfig holds configuration for Optimizely Webhooks
 type WebhookConfig struct {
-	Port     string                   `yaml:"port" json:"port"`
-	Projects map[int64]WebhookProject `mapstructure:"projects" json:"projects"`
+	Port     string                   `json:"port"`
+	Projects map[int64]WebhookProject `json:"projects"`
 }
 
 // WebhookProject holds the configuration for a single Project webhook
 type WebhookProject struct {
-	SDKKeys            []string `yaml:"sdkKeys" json:"sdkKeys"`
-	Secret             string   `yaml:"secret" json:"-"`
-	SkipSignatureCheck bool     `yaml:"skipSignatureCheck" json:"skipSignatureCheck" default:"false"`
+	SDKKeys            []string `json:"sdkKeys"`
+	Secret             string   `json:"-"`
+	SkipSignatureCheck bool     `json:"skipSignatureCheck" default:"false"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -43,4 +43,8 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Equal(t, "8085", conf.Webhook.Port)
 	assert.Empty(t, conf.Webhook.Projects)
+
+	assert.Equal(t, 10, conf.Processor.BatchSize)
+	assert.Equal(t, 1000, conf.Processor.QueueSize)
+	assert.Equal(t, 30*time.Second, conf.Processor.FlushInterval)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -26,6 +26,10 @@ import (
 func TestDefaultConfig(t *testing.T) {
 	conf := NewDefaultConfig()
 
+	assert.Equal(t, "", conf.Version)
+	assert.Equal(t, "Optimizely Inc.", conf.Author)
+	assert.Equal(t, "optimizely", conf.Name)
+
 	assert.Equal(t, 5*time.Second, conf.Server.ReadTimeout)
 	assert.Equal(t, 10*time.Second, conf.Server.WriteTimeout)
 
@@ -33,9 +37,6 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "info", conf.Log.Level)
 
 	assert.Equal(t, "8088", conf.Admin.Port)
-	assert.Equal(t, "", conf.Admin.Version)
-	assert.Equal(t, "Optimizely Inc.", conf.Admin.Author)
-	assert.Equal(t, "optimizely", conf.Admin.Name)
 
 	assert.Equal(t, 0, conf.API.MaxConns)
 	assert.Equal(t, "8080", conf.API.Port)

--- a/pkg/handlers/admin_entities.go
+++ b/pkg/handlers/admin_entities.go
@@ -21,9 +21,14 @@ import (
 	"expvar"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/go-chi/render"
+
+	"github.com/optimizely/agent/config"
 )
+
+var startTime = time.Now()
 
 // JSON is a map alias, just for convenience
 type JSON map[string]interface{}
@@ -34,17 +39,30 @@ type Health struct {
 	Reasons []string `json:"reasons,omitempty"`
 }
 
-// Admin is holding info to pass to admin handlers
-type Admin struct {
+// Info holds the detail to support the info endpoint
+type Info struct {
 	Version string `json:"version,omitempty"`
 	Author  string `json:"author,omitempty"`
 	AppName string `json:"app_name,omitempty"`
+	Uptime  string `json:"uptime"`
 	Host    string `json:"host,omitempty"`
 }
 
+// Admin is holding info to pass to admin handlers
+type Admin struct {
+	Config config.AgentConfig
+	Info   Info
+}
+
 // NewAdmin initializes admin
-func NewAdmin(version, author, appName string) *Admin {
-	return &Admin{Version: version, Author: author, AppName: appName}
+func NewAdmin(conf config.AgentConfig) *Admin {
+	info := Info{
+		Version: conf.Version,
+		Author:  conf.Author,
+		AppName: conf.Name,
+	}
+
+	return &Admin{Config: conf, Info: info}
 }
 
 // Health displays health status
@@ -54,16 +72,22 @@ func (a Admin) Health(w http.ResponseWriter, r *http.Request) {
 
 // AppInfo returns custom app-info
 func (a Admin) AppInfo(w http.ResponseWriter, r *http.Request) {
-	render.JSON(w, r, a)
+	a.Info.Uptime = time.Since(startTime).String()
+	render.JSON(w, r, a.Info)
+}
+
+// AppConfig returns the agent configuration
+func (a Admin) AppConfig(w http.ResponseWriter, r *http.Request) {
+	render.JSON(w, r, a.Config)
 }
 
 // AppInfoHeader adds custom app-info to the response header
 func (a Admin) AppInfoHeader(next http.Handler) http.Handler {
 	fn := func(w http.ResponseWriter, r *http.Request) {
 
-		w.Header().Set("Author", a.Author)
-		w.Header().Set("App-Name", a.AppName)
-		w.Header().Set("App-Version", a.Version)
+		w.Header().Set("Author", a.Info.Author)
+		w.Header().Set("App-Name", a.Info.AppName)
+		w.Header().Set("App-Version", a.Info.Version)
 		if host := os.Getenv("HOST"); host != "" {
 			w.Header().Set("Host", host)
 		}

--- a/pkg/handlers/admin_entities_test.go
+++ b/pkg/handlers/admin_entities_test.go
@@ -68,6 +68,23 @@ func TestAppInfoHandler(t *testing.T) {
 	assert.NotEmpty(t, actual.Uptime)
 }
 
+func TestAppConfigHandler(t *testing.T) {
+
+	req := httptest.NewRequest("GET", "/config", nil)
+	rec := httptest.NewRecorder()
+
+	a := NewAdmin(testConfig)
+	a.AppConfig(rec, req)
+
+	assert.Equal(t, http.StatusOK, rec.Code, "Status code differs")
+
+	actual := &config.AgentConfig{}
+	err := json.Unmarshal(rec.Body.Bytes(), actual)
+	assert.NoError(t, err)
+
+	assert.Equal(t, &testConfig, actual)
+}
+
 func TestAppInfoHeaderHandler(t *testing.T) {
 	req := httptest.NewRequest("GET", "/info", nil)
 	rec := httptest.NewRecorder()

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -38,7 +38,7 @@ type OptlyCache struct {
 	optlyMap        cmap.ConcurrentMap
 	ctx             context.Context
 	wg              sync.WaitGroup
-	conf            config.ProcessorConfig
+	processorConf   config.ProcessorConfig
 	metricsRegistry *MetricsRegistry
 }
 
@@ -49,7 +49,7 @@ func NewCache(ctx context.Context, conf config.ProcessorConfig, metricsRegistry 
 		wg:              sync.WaitGroup{},
 		loader:          initOptlyClient,
 		optlyMap:        cmap.New(),
-		conf:            conf,
+		processorConf:   conf,
 		metricsRegistry: metricsRegistry,
 	}
 
@@ -72,7 +72,7 @@ func (c *OptlyCache) GetClient(sdkKey string) (*OptlyClient, error) {
 		return val.(*OptlyClient), nil
 	}
 
-	oc, err := c.loader(sdkKey, c.conf, c.metricsRegistry)
+	oc, err := c.loader(sdkKey, c.processorConf, c.metricsRegistry)
 	if err != nil {
 		return oc, err
 	}

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -56,7 +56,8 @@ func NewCache(ctx context.Context, conf config.ProcessorConfig, metricsRegistry 
 	return cache
 }
 
-func (c *OptlyCache) init(sdkKeys []string) {
+// Init takes a slice of sdkKeys to warm the cache upon startup
+func (c *OptlyCache) Init(sdkKeys []string) {
 	for _, sdkKey := range sdkKeys {
 		if _, err := c.GetClient(sdkKey); err != nil {
 			log.Warn().Str("sdkKey", sdkKey).Msg("Failed to initialize Optimizely Client.")
@@ -71,7 +72,7 @@ func (c *OptlyCache) GetClient(sdkKey string) (*OptlyClient, error) {
 		return val.(*OptlyClient), nil
 	}
 
-	oc, err := c.loader(sdkKey, c.conf.Processor, c.metricsRegistry)
+	oc, err := c.loader(sdkKey, c.conf, c.metricsRegistry)
 	if err != nil {
 		return oc, err
 	}

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -38,12 +38,12 @@ type OptlyCache struct {
 	optlyMap        cmap.ConcurrentMap
 	ctx             context.Context
 	wg              sync.WaitGroup
-	conf            config.OptlyConfig
+	conf            config.ProcessorConfig
 	metricsRegistry *MetricsRegistry
 }
 
 // NewCache returns a new implementation of OptlyCache interface backed by a concurrent map.
-func NewCache(ctx context.Context, conf config.OptlyConfig, metricsRegistry *MetricsRegistry) *OptlyCache {
+func NewCache(ctx context.Context, conf config.ProcessorConfig, metricsRegistry *MetricsRegistry) *OptlyCache {
 	cache := &OptlyCache{
 		ctx:             ctx,
 		wg:              sync.WaitGroup{},
@@ -53,12 +53,11 @@ func NewCache(ctx context.Context, conf config.OptlyConfig, metricsRegistry *Met
 		metricsRegistry: metricsRegistry,
 	}
 
-	cache.init()
 	return cache
 }
 
-func (c *OptlyCache) init() {
-	for _, sdkKey := range c.conf.SDKKeys {
+func (c *OptlyCache) init(sdkKeys []string) {
+	for _, sdkKey := range sdkKeys {
 		if _, err := c.GetClient(sdkKey); err != nil {
 			log.Warn().Str("sdkKey", sdkKey).Msg("Failed to initialize Optimizely Client.")
 		}

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -78,8 +78,7 @@ func (suite *CacheTestSuite) TestGetError() {
 }
 
 func (suite *CacheTestSuite) TestInit() {
-	suite.cache.conf = config.OptlyConfig{SDKKeys: []string{"one"}}
-	suite.cache.init()
+	suite.cache.Init([]string{"one"})
 	suite.True(suite.cache.optlyMap.Has("one"))
 	suite.False(suite.cache.optlyMap.Has("two"))
 }

--- a/pkg/routers/admin.go
+++ b/pkg/routers/admin.go
@@ -28,14 +28,15 @@ import (
 )
 
 // NewAdminRouter returns HTTP admin router
-func NewAdminRouter(conf config.AdminConfig) http.Handler {
+func NewAdminRouter(conf config.AgentConfig) http.Handler {
 	r := chi.NewRouter()
 
-	optlyAdmin := handlers.NewAdmin(conf.Version, conf.Author, conf.Name)
+	optlyAdmin := handlers.NewAdmin(conf)
 	r.Use(optlyAdmin.AppInfoHeader)
 
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
+	r.Get("/config", optlyAdmin.AppConfig)
 	r.Get("/health", optlyAdmin.Health)
 	r.Get("/info", optlyAdmin.AppInfo)
 	r.Get("/metrics", optlyAdmin.Metrics)


### PR DESCRIPTION
## Summary
* Move Author, Name and Version to root config
* Move SDKKeys and Processor to root config
* Add uptime to /info because it seamed like a good idea
* Add admin /config route to support operations and validate config
* Updates README.md and config.yaml

Exposing "optly" in the configs was gross. Moving items to the root of the application config felt more appropriate in some cases as Agent _is_ optimizely. I also wanted to expose the configuration in the routes as this is a handy endpoint when you want to confirm that certain configs are loaded etc.