### PR TITLE
Support the latest master SDK version.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/go-chi/render v1.0.1
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
-	github.com/optimizely/go-sdk v1.0.1-0.20200115172509-b75e05a48376
+	github.com/optimizely/go-sdk v1.0.1-0.20200128173910-895dbc7355a5
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rs/zerolog v1.15.0
 	github.com/spf13/viper v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -80,8 +80,8 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/optimizely/go-sdk v1.0.1-0.20200115172509-b75e05a48376 h1:7UXN4lJu2DNJbHjyXY7ahVlHyyicIwI9SsUHMZOJZUI=
-github.com/optimizely/go-sdk v1.0.1-0.20200115172509-b75e05a48376/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
+github.com/optimizely/go-sdk v1.0.1-0.20200128173910-895dbc7355a5 h1:bpmrGA36u0sjfYgl0mWjmBxQXdEqq853sWjeExFjJvM=
+github.com/optimizely/go-sdk v1.0.1-0.20200128173910-895dbc7355a5/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/pkg/handlers/feature.go
+++ b/pkg/handlers/feature.go
@@ -25,14 +25,6 @@ import (
 	"github.com/optimizely/agent/pkg/middleware"
 )
 
-// Feature Model
-type Feature struct {
-	Key       string            `json:"key"`
-	Variables map[string]string `json:"variables,omitempty"`
-	ID        int32             `json:"id,omitempty"`
-	Enabled   bool              `json:"enabled"`
-}
-
 // FeatureHandler implements the FeatureAPI interface
 type FeatureHandler struct{}
 

--- a/pkg/handlers/user.go
+++ b/pkg/handlers/user.go
@@ -28,6 +28,14 @@ import (
 	"github.com/optimizely/agent/pkg/optimizely"
 )
 
+// Feature Model
+type Feature struct {
+	Key       string                 `json:"key"`
+	Variables map[string]interface{} `json:"variables,omitempty"`
+	ID        int32                  `json:"id,omitempty"`
+	Enabled   bool                   `json:"enabled"`
+}
+
 type eventTags map[string]interface{}
 
 // UserHandler implements the UserAPI interface

--- a/pkg/handlers/user_test.go
+++ b/pkg/handlers/user_test.go
@@ -378,7 +378,7 @@ func (suite *UserTestSuite) TestListFeatures() {
 		Feature{
 			Enabled: true,
 			Key:     "featureC",
-			Variables: map[string]string{
+			Variables: map[string]interface{}{
 				"strvar": "abc_notdef",
 			},
 		},
@@ -423,7 +423,7 @@ func (suite *UserTestSuite) TestTrackFeatures() {
 		Feature{
 			Enabled: true,
 			Key:     "featureC",
-			Variables: map[string]string{
+			Variables: map[string]interface{}{
 				"strvar": "abc_notdef",
 			},
 		},

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -49,7 +49,6 @@ func (c *OptlyClient) ListFeatures() (features []optimizelyconfig.OptimizelyFeat
 	return features, err
 }
 
-
 // ErrEntityNotFound is returned when no entity exists with a given key
 var ErrEntityNotFound = errors.New("not found")
 
@@ -99,7 +98,7 @@ func (c *OptlyClient) GetExperiment(experimentKey string) (optimizelyconfig.Opti
 // UpdateConfig uses config manager to sync and set project config
 func (c *OptlyClient) UpdateConfig() {
 	if c.ConfigManager != nil {
-		c.ConfigManager.SyncConfig([]byte{})
+		c.ConfigManager.SyncConfig()
 	}
 }
 
@@ -109,7 +108,7 @@ func (c *OptlyClient) TrackEventWithContext(eventKey string, ctx *OptlyContext, 
 }
 
 // GetFeatureWithContext calls the OptimizelyClient with the current OptlyContext
-func (c *OptlyClient) GetFeatureWithContext(featureKey string, ctx *OptlyContext) (enabled bool, variableMap map[string]string, err error) {
+func (c *OptlyClient) GetFeatureWithContext(featureKey string, ctx *OptlyContext) (enabled bool, variableMap map[string]interface{}, err error) {
 	return c.GetAllFeatureVariables(featureKey, *ctx.UserContext)
 }
 

--- a/pkg/optimizely/optimizelytest/processor.go
+++ b/pkg/optimizely/optimizelytest/processor.go
@@ -17,7 +17,14 @@
 // Package optimizelytest //
 package optimizelytest
 
-import "github.com/optimizely/go-sdk/pkg/event"
+import (
+	"errors"
+
+	"github.com/optimizely/go-sdk/pkg/event"
+)
+
+// ErrNotImplemented indicates that the error was returned since the functionality was not implemented
+var ErrNotImplemented = errors.New("not implemented")
 
 // TestEventProcessor implements an Optimizely Processor to aid in testing
 type TestEventProcessor struct {
@@ -36,4 +43,14 @@ func (p *TestEventProcessor) GetEvents() []event.UserEvent {
 	copy(c, p.events)
 
 	return c
+}
+
+// OnEventDispatch is a non-op notification action
+func (p *TestEventProcessor) OnEventDispatch(callback func(logEvent event.LogEvent)) (int, error) {
+	return 0, ErrNotImplemented
+}
+
+// RemoveOnEventDispatch is a non-op notification action
+func (p *TestEventProcessor) RemoveOnEventDispatch(id int) error {
+	return ErrNotImplemented
 }


### PR DESCRIPTION
## Summary
* Use the latest master where GetAllFeatureVariables returns a `map[string]interface{}`
* Updates to the latest `ProjectConfig` interface

Note that the original ticket called for an override mechanism via service config and a URL parameter. That implementation will be dependent on the current [RFP](https://github.com/optimizely/agent/pull/133), so we should wait until that change is merged before adding that capability.