### PR TITLE
Add nil query param support.

### DIFF
--- a/pkg/middleware/cached_test.go
+++ b/pkg/middleware/cached_test.go
@@ -119,6 +119,7 @@ func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 		"int":          int64(100),
 		"float":        1.00,
 		"quotedString": "true",
+		"nil":          nil,
 	}
 	expected := optimizely.NewContext("test", attributes)
 
@@ -126,7 +127,7 @@ func (suite *OptlyMiddlewareTestSuite) TestGetUserContext() {
 	handler := AssertOptlyContextHandler(suite, expected)
 	mux.With(suite.mw.UserCtx).Get("/{userID}", handler)
 
-	req := httptest.NewRequest("GET", `/test?bool=true&str=yes&int=100&float=1.0&quotedString="true"`, nil)
+	req := httptest.NewRequest("GET", `/test?bool=true&str=yes&int=100&float=1.0&quotedString="true"&nil=`, nil)
 	rec := httptest.NewRecorder()
 
 	mux.ServeHTTP(rec, req)

--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -114,5 +114,9 @@ func CoerceType(s string) interface{} {
 		return true
 	}
 
+	if s == "" {
+		return nil
+	}
+
 	return s
 }


### PR DESCRIPTION
## Summary
* Treat empty query params as nil
* Empty strings can be passed as `key=""`

Currently empty query values are treated as strings which fails the compatibility suite use cases.