### PR TITLE
feat: token acceptor for admin and api

### DIFF
--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -1,0 +1,175 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                   *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package middleware //
+package middleware
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/dgrijalva/jwt-go"
+)
+
+func getNumberFromJSON(val interface{}) int64 {
+	switch v := val.(type) {
+	case int64:
+		return v
+	case float64:
+		return int64(v)
+	}
+	return 0
+}
+
+// NoAuth is NoOp for auth
+type NoAuth struct{}
+
+// CheckToken returns no token and no error
+func (NoAuth) CheckToken(string) (*jwt.Token, error) {
+	return nil, nil
+}
+
+// Auth is the middleware for all REST API's
+type Auth struct {
+	Verifier
+
+	checkClaims map[string]struct{}
+}
+
+// Verifier checks token
+type Verifier interface {
+	CheckToken(string) (*jwt.Token, error)
+}
+
+// JWTVerifier checks token with JWT, implements Verifier
+type JWTVerifier struct {
+	secretKey string
+}
+
+// NewJWTVerifier creates JWTVerifier with secret key
+func NewJWTVerifier(secretKey string) JWTVerifier {
+	return JWTVerifier{secretKey: secretKey}
+}
+
+// CheckToken checks the token and returns it if it's valid
+func (c JWTVerifier) CheckToken(token string) (*jwt.Token, error) {
+	if token == "" {
+		return nil, errors.New("invalid token")
+	}
+
+	tk, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, errors.New("unexpected signing method")
+		}
+		return []byte(c.secretKey), nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if !tk.Valid {
+		return nil, errors.New("invalid token")
+	}
+
+	return tk, nil
+}
+
+func (a Auth) verify(r *http.Request) (*jwt.Token, error) {
+
+	var token string
+
+	if values, ok := r.Header["Auth"]; ok && len(values) > 0 {
+		token = values[0]
+	}
+
+	if values, ok := r.Header["Jwt"]; ok && len(values) > 0 {
+		token = values[0]
+	}
+
+	if values, ok := r.Header["Authorization"]; ok && len(values) > 0 {
+		value := values[0]
+		for _, key := range []string{"JWT", "Bearer"} {
+			token = strings.TrimSpace(strings.TrimLeft(value, key))
+		}
+	}
+
+	return a.CheckToken(token)
+
+}
+
+func (a Auth) enabled() bool {
+	if _, ok := a.Verifier.(NoAuth); ok {
+		return false
+	}
+	return true
+}
+
+// Authorize is middleware for auth
+func (a Auth) Authorize(next http.Handler) http.Handler {
+	fn := func(w http.ResponseWriter, r *http.Request) {
+
+		tk, err := a.verify(r)
+
+		if err != nil {
+			http.Error(w, fmt.Sprintf(`{"error": "unauthorized, "reason": "%v"}`, err), http.StatusUnauthorized)
+			return
+		}
+
+		if a.enabled() {
+			claims := tk.Claims.(jwt.MapClaims)
+
+			for key := range a.checkClaims {
+
+				value, ok := claims[key]
+				if !ok {
+					http.Error(w, fmt.Sprintf(`{"error": "unauthorized, "reason": "%s key not in claims"}`, key), http.StatusUnauthorized)
+					return
+				}
+
+				switch key {
+				case "exp":
+					if expired := (getNumberFromJSON(value) - time.Now().Unix()) <= 0; expired {
+						http.Error(w, `{"error": "unauthorized", "reason": "token expired"}`, http.StatusUnauthorized)
+						return
+					}
+
+				case "sdk_key":
+					sdkKeyFromHeader := r.Header.Get(OptlySDKHeader)
+					if sdkKey, ok := value.(string); !ok || sdkKey != sdkKeyFromHeader {
+						http.Error(w, `{"error": "unauthorized", "reason": "SDK keys not equal"}`, http.StatusUnauthorized)
+						return
+					}
+				case "admin":
+					if adminFlag, ok := value.(bool); !ok || !adminFlag {
+						http.Error(w, `{"error": "unauthorized", "reason": "admin flag not set"}`, http.StatusUnauthorized)
+						return
+					}
+				}
+			}
+		}
+
+		next.ServeHTTP(w, r)
+	}
+	return http.HandlerFunc(fn)
+}
+
+// NewAuth makes Auth middleware
+func NewAuth(v Verifier, checkClaims map[string]struct{}) Auth {
+	return Auth{Verifier: v, checkClaims: checkClaims}
+}

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -1,0 +1,164 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package middleware //
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/dgrijalva/jwt-go"
+	"github.com/stretchr/testify/suite"
+)
+
+type OptlyClaims struct {
+	ExpiresAt int64  `json:"exp,omitempty"`
+	Issuer    string `json:"iss,omitempty"`
+	SdkKey    string `json:"sdk_key,omitempty"`
+}
+
+func (c OptlyClaims) Valid() error {
+	return nil
+}
+
+type AuthTestSuite struct {
+	suite.Suite
+	validToken   *jwt.Token
+	expiredToken *jwt.Token
+	handler      http.HandlerFunc
+	signature    string
+}
+
+func (suite *AuthTestSuite) SetupTest() {
+	suite.signature = "test"
+	claims := OptlyClaims{ExpiresAt: 12313123123213, SdkKey: "SDK_KEY", Issuer: "iss"} // exp = March 9, 2360
+	suite.validToken = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	suite.validToken.Raw, _ = suite.validToken.SignedString([]byte(suite.signature))
+
+	claims = OptlyClaims{ExpiresAt: 0, SdkKey: "SDK_KEY", Issuer: "iss"}
+	suite.expiredToken = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	suite.expiredToken.Raw, _ = suite.expiredToken.SignedString([]byte(suite.signature))
+
+	suite.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
+
+}
+
+func (suite *AuthTestSuite) TestNoAuthCheckToken() {
+
+	auth := NewAuth(NoAuth{}, map[string]struct{}{})
+	token, err := auth.CheckToken("")
+	suite.Nil(token)
+	suite.NoError(err)
+}
+
+func (suite *AuthTestSuite) TestNoAuthAuthorize() {
+
+	auth := NewAuth(NoAuth{}, map[string]struct{}{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthValidCheckToken() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{})
+	token, err := auth.CheckToken(suite.validToken.Raw)
+	suite.Equal(suite.validToken.Raw, token.Raw)
+	suite.NoError(err)
+}
+
+func (suite *AuthTestSuite) TestAuthInvalidCheckToken() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{})
+	token, err := auth.CheckToken("adasdsada.sfsdfs.adas")
+	suite.Nil(token)
+	suite.Error(err)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeEmptyToken() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusUnauthorized, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeToken() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Add("Auth", suite.validToken.Raw)
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+
+	suite.Equal(http.StatusOK, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeTokenAuthorization() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Add("Authorization", "Bearer "+suite.validToken.Raw)
+
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeTokenInvalidClaims() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{"sdk_key": {}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Add("Authorization", "Bearer "+suite.validToken.Raw)
+
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusUnauthorized, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeTokenAuthorizationValidClaims() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{"sdk_key": {}, "exp": {}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Add("Authorization", "Bearer "+suite.validToken.Raw)
+	req.Header.Add(OptlySDKHeader, "SDK_KEY")
+
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeTokenAuthorizationValidClaimsExpiredToken() {
+
+	auth := NewAuth(NewJWTVerifier(suite.signature), map[string]struct{}{"exp": {}})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Add("Authorization", "Bearer "+suite.expiredToken.Raw)
+	req.Header.Add(OptlySDKHeader, "SDK_KEY")
+
+	auth.Authorize(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusUnauthorized, rec.Code)
+}
+
+func TestAuth(t *testing.T) {
+	suite.Run(t, new(AuthTestSuite))
+}

--- a/pkg/routers/admin.go
+++ b/pkg/routers/admin.go
@@ -20,6 +20,7 @@ package routers
 import (
 	"github.com/optimizely/agent/config"
 	"github.com/optimizely/agent/pkg/handlers"
+	"github.com/optimizely/agent/pkg/middleware"
 
 	"net/http"
 
@@ -31,15 +32,25 @@ import (
 func NewAdminRouter(conf config.AgentConfig) http.Handler {
 	r := chi.NewRouter()
 
+	var authProvider middleware.Auth
+	checkClaims := map[string]struct{}{"exp": {}, "admin": {}}
+	if conf.Admin.Auth.HMACSecret == "" {
+		authProvider = middleware.NewAuth(middleware.NoAuth{}, checkClaims)
+	} else {
+		authProvider = middleware.NewAuth(middleware.NewJWTVerifier(conf.Admin.Auth.HMACSecret), checkClaims)
+	}
+
 	optlyAdmin := handlers.NewAdmin(conf)
+	tokenHandler := handlers.NewOAuthHandler(&conf.Admin.Auth)
 	r.Use(optlyAdmin.AppInfoHeader)
 
 	r.Use(render.SetContentType(render.ContentTypeJSON))
 
-	r.Get("/config", optlyAdmin.AppConfig)
-	r.Get("/health", optlyAdmin.Health)
-	r.Get("/info", optlyAdmin.AppInfo)
-	r.Get("/metrics", optlyAdmin.Metrics)
+	r.With(authProvider.Authorize).Get("/config", optlyAdmin.AppConfig)
+	r.With(authProvider.Authorize).Get("/health", optlyAdmin.Health)
+	r.With(authProvider.Authorize).Get("/info", optlyAdmin.AppInfo)
+	r.With(authProvider.Authorize).Get("/metrics", optlyAdmin.Metrics)
 
+	r.Post("/oauth/token", tokenHandler.GetAdminAccessToken)
 	return r
 }

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -41,10 +41,21 @@ type APIOptions struct {
 	notificationsAPI handlers.NotificationAPI
 	userOverrideAPI  handlers.UserOverrideAPI
 	metricsRegistry  *metrics.Registry
+	oAuthHandler     *handlers.OAuthHandler
+	oAuthMiddleware  middleware.Auth
 }
 
 // NewDefaultAPIRouter creates a new router with the default backing optimizely.Cache
 func NewDefaultAPIRouter(optlyCache optimizely.Cache, conf config.APIConfig, metricsRegistry *metrics.Registry) http.Handler {
+
+	var authProvider middleware.Auth
+	checkClaims := map[string]struct{}{"exp": {}, "sdk_key": {}}
+	if conf.Auth.HMACSecret == "" {
+		authProvider = middleware.NewAuth(middleware.NoAuth{}, checkClaims)
+	} else {
+		authProvider = middleware.NewAuth(middleware.NewJWTVerifier(conf.Auth.HMACSecret), checkClaims)
+	}
+
 	spec := &APIOptions{
 		maxConns:         conf.MaxConns,
 		middleware:       &middleware.CachedOptlyMiddleware{Cache: optlyCache},
@@ -54,6 +65,8 @@ func NewDefaultAPIRouter(optlyCache optimizely.Cache, conf config.APIConfig, met
 		notificationsAPI: handlers.NewNotificationHandler(),
 		userOverrideAPI:  new(handlers.UserOverrideHandler),
 		metricsRegistry:  metricsRegistry,
+		oAuthHandler:     handlers.NewOAuthHandler(&conf.Auth),
+		oAuthMiddleware:  authProvider,
 	}
 
 	return NewAPIRouter(spec)
@@ -88,20 +101,20 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 	}
 
 	r.Route("/notifications/event-stream", func(r chi.Router) {
-		r.Use(opt.middleware.ClientCtx)
+		r.Use(opt.middleware.ClientCtx, opt.oAuthMiddleware.Authorize)
 		r.Get("/", opt.notificationsAPI.HandleEventSteam)
 	})
 
 	r.Route("/features", func(r chi.Router) {
 		setMiddleWareTime(r)
-		r.Use(opt.middleware.ClientCtx)
+		r.Use(opt.middleware.ClientCtx, opt.oAuthMiddleware.Authorize)
 		r.With(listFeaturesTimer).Get("/", opt.featureAPI.ListFeatures)
 		r.With(getFeatureTimer, opt.middleware.FeatureCtx).Get("/{featureKey}", opt.featureAPI.GetFeature)
 	})
 
 	r.Route("/experiments", func(r chi.Router) {
 		setMiddleWareTime(r)
-		r.Use(opt.middleware.ClientCtx)
+		r.Use(opt.middleware.ClientCtx, opt.oAuthMiddleware.Authorize)
 		r.With(listExperimentsTimer).Get("/", opt.experimentAPI.ListExperiments)
 		r.With(getExperimentTimer, opt.middleware.ExperimentCtx).Get("/{experimentKey}", opt.experimentAPI.GetExperiment)
 	})
@@ -109,7 +122,7 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 	r.Route("/users/{userID}", func(r chi.Router) {
 		setMiddleWareTime(r)
 
-		r.Use(opt.middleware.ClientCtx, opt.middleware.UserCtx)
+		r.Use(opt.middleware.ClientCtx, opt.middleware.UserCtx, opt.oAuthMiddleware.Authorize)
 
 		r.With(trackEventTimer).Post("/events/{eventKey}", opt.userAPI.TrackEvent)
 
@@ -122,11 +135,12 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 	})
 
 	r.Route("/overrides/users/{userID}", func(r chi.Router) {
-		r.Use(opt.middleware.ClientCtx, opt.middleware.UserCtx)
+		r.Use(opt.middleware.ClientCtx, opt.middleware.UserCtx, opt.oAuthMiddleware.Authorize)
 
 		r.With(setForcedVariationTimer).Put("/experiments/{experimentKey}", opt.userOverrideAPI.SetForcedVariation)
 		r.With(removeForcedVariationTimer).Delete("/experiments/{experimentKey}", opt.userOverrideAPI.RemoveForcedVariation)
 	})
 
+	r.Post("/oauth/token", opt.oAuthHandler.GetAPIAccessToken)
 	return r
 }

--- a/pkg/routers/api_test.go
+++ b/pkg/routers/api_test.go
@@ -27,7 +27,9 @@ import (
 	"github.com/go-chi/chi"
 	"github.com/go-chi/render"
 
+	"github.com/optimizely/agent/pkg/handlers"
 	"github.com/optimizely/agent/pkg/metrics"
+	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely/optimizelytest"
 
 	"github.com/stretchr/testify/assert"
@@ -168,6 +170,8 @@ func (suite *RouterTestSuite) SetupTest() {
 		userOverrideAPI:  new(MockUserOverrideAPI),
 		middleware:       new(MockOptlyMiddleware),
 		metricsRegistry:  metricsRegistry,
+		oAuthHandler:     &handlers.OAuthHandler{},
+		oAuthMiddleware:  middleware.Auth{Verifier: middleware.NoAuth{}},
 	}
 
 	suite.mux = NewAPIRouter(opts)


### PR DESCRIPTION
## Summary
- adding Authorize middleware for accepting a token when auth is enabled 
- for now enabled/disabled auth is determined by the presence of auth object in config file