### PR TITLE
feat: Add blacklist for crypto cyphers

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -39,6 +39,7 @@ func assertServer(t *testing.T, actual config.ServerConfig) {
 	assert.Equal(t, 10*time.Second, actual.WriteTimeout)
 	assert.Equal(t, "keyfile", actual.KeyFile)
 	assert.Equal(t, "certfile", actual.CertFile)
+	assert.Equal(t, []uint16{0xc00a, 0xc011}, actual.DisabledCiphers)
 }
 
 func assertLog(t *testing.T, actual config.LogConfig) {
@@ -111,6 +112,7 @@ func TestViperProps(t *testing.T) {
 	v.Set("server.writetimeout", 10*time.Second)
 	v.Set("server.certfile", "certfile")
 	v.Set("server.keyfile", "keyfile")
+	v.Set("server.disabledciphers", "0xc00a,0xc011")
 
 	v.Set("log.pretty", true)
 	v.Set("log.level", "debug")
@@ -167,6 +169,7 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_SERVER_WRITETIMEOUT", "10s")
 	_ = os.Setenv("OPTIMIZELY_SERVER_CERTFILE", "certfile")
 	_ = os.Setenv("OPTIMIZELY_SERVER_KEYFILE", "keyfile")
+	_ = os.Setenv("OPTIMIZELY_SERVER_DISABLEDCIPHERS", "0xc00a,0xc011")
 
 	_ = os.Setenv("OPTIMIZELY_LOG_PRETTY", "true")
 	_ = os.Setenv("OPTIMIZELY_LOG_LEVEL", "debug")

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -10,6 +10,9 @@ server:
   writeTimeout: 10s
   keyfile: "keyfile"
   certfile: "certfile"
+  disabledciphers:
+    - 0xc00a
+    - 0xc011
 log:
   pretty: true
   level: debug

--- a/config/config.go
+++ b/config/config.go
@@ -56,10 +56,11 @@ func NewDefaultConfig() *AgentConfig {
 			FlushInterval: 30 * time.Second,
 		},
 		Server: ServerConfig{
-			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 10 * time.Second,
-			CertFile:     "",
-			KeyFile:      "",
+			ReadTimeout:     5 * time.Second,
+			WriteTimeout:    10 * time.Second,
+			CertFile:        "",
+			KeyFile:         "",
+			DisabledCiphers: make([]uint16, 0),
 		},
 		Webhook: WebhookConfig{
 			Port: "8085",
@@ -100,10 +101,11 @@ type LogConfig struct {
 
 // ServerConfig holds the global http server configs
 type ServerConfig struct {
-	ReadTimeout  time.Duration `json:"readtimeout"`
-	WriteTimeout time.Duration `json:"writetimeout"`
-	CertFile     string        `json:"certfile"`
-	KeyFile      string        `json:"keyfile"`
+	ReadTimeout     time.Duration `json:"readtimeout"`
+	WriteTimeout    time.Duration `json:"writetimeout"`
+	CertFile        string        `json:"certfile"`
+	KeyFile         string        `json:"keyfile"`
+	DisabledCiphers []uint16      `json:"disabledciphers"`
 }
 
 // APIConfig holds the REST API configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,6 +34,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Second, conf.Server.WriteTimeout)
 	assert.Equal(t, "", conf.Server.KeyFile)
 	assert.Equal(t, "", conf.Server.CertFile)
+	assert.Equal(t, []uint16{}, conf.Server.DisabledCiphers)
 
 	assert.False(t, conf.Log.Pretty)
 	assert.Equal(t, "info", conf.Log.Level)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -17,6 +17,7 @@
 package server
 
 import (
+	"crypto/tls"
 	"github.com/optimizely/agent/config"
 	"net/http"
 	"sync"
@@ -99,4 +100,28 @@ func TestTSLServerConfigs(t *testing.T) {
 	assert.Equal(t, cfg.ReadTimeout, ns.srv.ReadTimeout)
 	assert.Equal(t, cfg.WriteTimeout, ns.srv.WriteTimeout)
 	assert.NotNil(t, ns.srv.TLSConfig)
+}
+
+func TestBlacklistCiphers(t *testing.T) {
+
+	blacklist := []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	}
+
+	defaultCiphers := []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+	ciphers := blacklistCiphers(blacklist, defaultCiphers)
+
+	expectedCiphers := []uint16{
+		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+	}
+	assert.Equal(t, expectedCiphers, ciphers)
+
 }


### PR DESCRIPTION
## Summary
- add a configurable blacklist for ciphers
- the implementation removes the cipher from our default config if that cipher is blacklisted
- blacklist is provided in configuration as a list of cipher hexadecimal values 