### PR TITLE
Revert to str for legacy api.

### DIFF
--- a/pkg/handlers/user.go
+++ b/pkg/handlers/user.go
@@ -204,13 +204,20 @@ func parseContext(r *http.Request) (*optimizely.OptlyClient, *optimizely.OptlyCo
 // getModelOfFeatureDecision - Returns a Feature representing the feature decision from the provided client and context
 func getModelOfFeatureDecision(featureKey string, optlyClient *optimizely.OptlyClient, optlyContext *optimizely.OptlyContext) (*Feature, error) {
 	enabled, variables, err := optlyClient.GetFeatureWithContext(featureKey, optlyContext)
+
+	// For backwards compatibilty all variables need to be retutned as a string
+	strVars := make(map[string]interface{}, len(variables))
+	for k, v := range variables {
+		strVars[k] = fmt.Sprintf("%v", v)
+	}
+
 	if err != nil {
 		return nil, err
 	}
 	return &Feature{
 		Key:       featureKey,
 		Enabled:   enabled,
-		Variables: variables,
+		Variables: strVars,
 	}, nil
 }
 

--- a/pkg/handlers/user.go
+++ b/pkg/handlers/user.go
@@ -205,7 +205,7 @@ func parseContext(r *http.Request) (*optimizely.OptlyClient, *optimizely.OptlyCo
 func getModelOfFeatureDecision(featureKey string, optlyClient *optimizely.OptlyClient, optlyContext *optimizely.OptlyContext) (*Feature, error) {
 	enabled, variables, err := optlyClient.GetFeatureWithContext(featureKey, optlyContext)
 
-	// For backwards compatibilty all variables need to be retutned as a string
+	// For backwards compatibility all variables need to be returned as a string
 	strVars := make(map[string]interface{}, len(variables))
 	for k, v := range variables {
 		strVars[k] = fmt.Sprintf("%v", v)

--- a/pkg/handlers/user_test.go
+++ b/pkg/handlers/user_test.go
@@ -143,7 +143,17 @@ func (suite *UserTestSuite) TestGetFeatureWithFeatureTest() {
 }
 
 func (suite *UserTestSuite) TestTrackFeatureWithFeatureRollout() {
-	feature := entities.Feature{Key: "one"}
+
+	strvar := entities.Variable{DefaultValue: "default", ID: "123", Key: "strvar", Type: "string"}
+	intvar := entities.Variable{DefaultValue: "123", ID: "124", Key: "intvar", Type: "integer"}
+	doublevar := entities.Variable{DefaultValue: "123.99", ID: "125", Key: "doublevar", Type: "double"}
+	boolvar := entities.Variable{DefaultValue: "true", ID: "126", Key: "boolvar", Type: "boolean"}
+	feature := entities.Feature{Key: "one", VariableMap: map[string]entities.Variable{
+		"strvar":    strvar,
+		"intvar":    intvar,
+		"doublevar": doublevar,
+		"boolvar":   boolvar,
+	}}
 	suite.tc.AddFeatureRollout(feature)
 
 	req := httptest.NewRequest("POST", "/features/one", nil)
@@ -160,6 +170,12 @@ func (suite *UserTestSuite) TestTrackFeatureWithFeatureRollout() {
 	expected := Feature{
 		Key:     "one",
 		Enabled: true,
+		Variables: map[string]interface{}{
+			"strvar":    "default",
+			"intvar":    "123",
+			"doublevar": "123.99",
+			"boolvar":   "true",
+		},
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))


### PR DESCRIPTION
## Summary
* Customer of the legacy API endpoints expect string variables
* New /v1 returns typed-variables, this still needs to be made configurable (future PR)

