### PR TITLE
feat: Disable /notifications and /overrides by default

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -62,6 +62,8 @@ func assertAdminAuth(t *testing.T, actual config.ServiceAuthConfig) {
 func assertAPI(t *testing.T, actual config.APIConfig) {
 	assert.Equal(t, 100, actual.MaxConns)
 	assert.Equal(t, "3000", actual.Port)
+	assert.Equal(t, true, actual.EnableNotifications)
+	assert.Equal(t, true, actual.EnableOverrides)
 }
 
 func assertAPIAuth(t *testing.T, actual config.ServiceAuthConfig) {
@@ -126,6 +128,8 @@ func TestViperProps(t *testing.T) {
 	})
 
 	v.Set("api.maxconns", 100)
+	v.Set("api.enablenotifications", true)
+	v.Set("api.enableoverrides", true)
 	v.Set("api.port", "3000")
 	v.Set("api.auth.ttl", "30m")
 	v.Set("api.auth.hmacsecret", "abcd")
@@ -175,6 +179,8 @@ func TestViperEnv(t *testing.T) {
 
 	_ = os.Setenv("OPTIMIZELY_API_MAXCONNS", "100")
 	_ = os.Setenv("OPTIMIZELY_API_PORT", "3000")
+	_ = os.Setenv("OPTIMIZELY_API_ENABLENOTIFICATIONS", "true")
+	_ = os.Setenv("OPTIMIZELY_API_ENABLEOVERRIDES", "true")
 
 	_ = os.Setenv("OPTIMIZELY_WEBHOOK_PORT", "3001")
 	_ = os.Setenv("OPTIMIZELY_WEBHOOK_PROJECTS_10000_SECRET", "secret-10000")

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -24,6 +24,8 @@ admin:
 api:
   maxconns: 100
   port: "3000"
+  enablenotifications: true
+  enableoverrides: true
   auth:
     ttl: 30m
     hmacSecret: "abcd"

--- a/config/config.go
+++ b/config/config.go
@@ -43,8 +43,10 @@ func NewDefaultConfig() *AgentConfig {
 				HMACSecret: "",
 				TTL:        0,
 			},
-			MaxConns: 0,
-			Port:     "8080",
+			MaxConns:            0,
+			Port:                "8080",
+			EnableNotifications: false,
+			EnableOverrides:     false,
 		},
 		Log: LogConfig{
 			Pretty: false,
@@ -108,9 +110,11 @@ type ServerConfig struct {
 
 // APIConfig holds the REST API configuration
 type APIConfig struct {
-	Auth     ServiceAuthConfig `json:"-"`
-	MaxConns int               `json:"maxconns"`
-	Port     string            `json:"port"`
+	Auth                ServiceAuthConfig `json:"-"`
+	MaxConns            int               `json:"maxconns"`
+	Port                string            `json:"port"`
+	EnableNotifications bool              `json:"enablenotifications"`
+	EnableOverrides     bool              `json:"enableoverrides"`
 }
 
 // AdminConfig holds the configuration for the admin web interface

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -48,6 +48,8 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, make([]OAuthClientCredentials, 0), conf.API.Auth.Clients)
 	assert.Equal(t, "", conf.API.Auth.HMACSecret)
 	assert.Equal(t, time.Duration(0), conf.API.Auth.TTL)
+	assert.Equal(t, false, conf.API.EnableOverrides)
+	assert.Equal(t, false, conf.API.EnableNotifications)
 
 	assert.Equal(t, "8085", conf.Webhook.Port)
 	assert.Empty(t, conf.Webhook.Projects)

--- a/pkg/handlers/notification_disabled.go
+++ b/pkg/handlers/notification_disabled.go
@@ -1,0 +1,37 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"net/http"
+)
+
+// DisableNotificationHandler for disabled notifications
+type DisableNotificationHandler struct {
+}
+
+// HandleEventSteam implements the http.Handler interface. Returns forbidden status
+func (nh *DisableNotificationHandler) HandleEventSteam(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Streaming not enabled", http.StatusForbidden)
+}
+
+// NewDisableNotificationHandler is the DisableNotificationHandler factory
+func NewDisableNotificationHandler() (nh *DisableNotificationHandler) {
+	return &DisableNotificationHandler{}
+
+}

--- a/pkg/handlers/notification_disabled.go
+++ b/pkg/handlers/notification_disabled.go
@@ -21,17 +21,17 @@ import (
 	"net/http"
 )
 
-// DisableNotificationHandler for disabled notifications
-type DisableNotificationHandler struct {
+// DisabledNotificationHandler for disabled notifications
+type DisabledNotificationHandler struct {
 }
 
 // HandleEventSteam implements the http.Handler interface. Returns forbidden status
-func (nh *DisableNotificationHandler) HandleEventSteam(w http.ResponseWriter, r *http.Request) {
+func (nh *DisabledNotificationHandler) HandleEventSteam(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Streaming not enabled", http.StatusForbidden)
 }
 
-// NewDisableNotificationHandler is the DisableNotificationHandler factory
-func NewDisableNotificationHandler() (nh *DisableNotificationHandler) {
-	return &DisableNotificationHandler{}
+// NewDisabledNotificationHandler is the DisableNotificationHandler factory
+func NewDisabledNotificationHandler() (nh *DisabledNotificationHandler) {
+	return &DisabledNotificationHandler{}
 
 }

--- a/pkg/handlers/notification_disabled_test.go
+++ b/pkg/handlers/notification_disabled_test.go
@@ -35,7 +35,7 @@ type NotificationDisabledTestSuite struct {
 func (suite *NotificationDisabledTestSuite) SetupTest() {
 
 	mux := chi.NewMux()
-	eventsAPI := NewDisableNotificationHandler()
+	eventsAPI := NewDisabledNotificationHandler()
 
 	mux.Get("/notifications/event-stream", eventsAPI.HandleEventSteam)
 

--- a/pkg/handlers/notification_disabled_test.go
+++ b/pkg/handlers/notification_disabled_test.go
@@ -1,0 +1,61 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/suite"
+)
+
+type NotificationDisabledTestSuite struct {
+	suite.Suite
+	mux *chi.Mux
+}
+
+// Setup Mux
+func (suite *NotificationDisabledTestSuite) SetupTest() {
+
+	mux := chi.NewMux()
+	eventsAPI := NewDisableNotificationHandler()
+
+	mux.Get("/notifications/event-stream", eventsAPI.HandleEventSteam)
+
+	suite.mux = mux
+
+}
+
+func (suite *NotificationDisabledTestSuite) TestEventStream() {
+	req := httptest.NewRequest("GET", "/notifications/event-stream?", nil)
+	rec := httptest.NewRecorder()
+
+	suite.mux.ServeHTTP(rec, req)
+
+	suite.Equal(http.StatusForbidden, rec.Code)
+
+	// Unmarshal response
+	response := string(rec.Body.Bytes())
+	suite.Equal("Streaming not enabled\n", response)
+}
+
+func TestDisabledEventStreamTestSuite(t *testing.T) {
+	suite.Run(t, new(NotificationDisabledTestSuite))
+}

--- a/pkg/handlers/user_overrides_disabled.go
+++ b/pkg/handlers/user_overrides_disabled.go
@@ -21,16 +21,16 @@ import (
 	"net/http"
 )
 
-// DisableUserOverrideHandler implements the disabled overrides
-type DisableUserOverrideHandler struct{}
+// DisabledUserOverrideHandler implements the disabled overrides
+type DisabledUserOverrideHandler struct{}
 
 // SetForcedVariation - set a forced variation
-func (h *DisableUserOverrideHandler) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
+func (h *DisabledUserOverrideHandler) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Overrides not enabled", http.StatusForbidden)
 
 }
 
 // RemoveForcedVariation - Remove a forced variation
-func (h *DisableUserOverrideHandler) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
+func (h *DisabledUserOverrideHandler) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Overrides not enabled", http.StatusForbidden)
 }

--- a/pkg/handlers/user_overrides_disabled.go
+++ b/pkg/handlers/user_overrides_disabled.go
@@ -1,0 +1,36 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"net/http"
+)
+
+// DisableUserOverrideHandler implements the disabled overrides
+type DisableUserOverrideHandler struct{}
+
+// SetForcedVariation - set a forced variation
+func (h *DisableUserOverrideHandler) SetForcedVariation(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Overrides not enabled", http.StatusForbidden)
+
+}
+
+// RemoveForcedVariation - Remove a forced variation
+func (h *DisableUserOverrideHandler) RemoveForcedVariation(w http.ResponseWriter, r *http.Request) {
+	http.Error(w, "Overrides not enabled", http.StatusForbidden)
+}

--- a/pkg/handlers/user_overrides_disabled_test.go
+++ b/pkg/handlers/user_overrides_disabled_test.go
@@ -37,7 +37,7 @@ type UserOverridesDisabledTestSuite struct {
 func (suite *UserOverridesDisabledTestSuite) SetupTest() {
 
 	mux := chi.NewMux()
-	userAPI := new(DisableUserOverrideHandler)
+	userAPI := new(DisabledUserOverrideHandler)
 
 	mux.Put("/experiments/{experimentKey}", userAPI.SetForcedVariation)
 	mux.Delete("/experiments/{experimentKey}", userAPI.RemoveForcedVariation)

--- a/pkg/handlers/user_overrides_disabled_test.go
+++ b/pkg/handlers/user_overrides_disabled_test.go
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * Copyright 2020, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-chi/chi"
+	"github.com/stretchr/testify/suite"
+)
+
+type UserOverridesDisabledTestSuite struct {
+	suite.Suite
+	mux *chi.Mux
+}
+
+// Setup Mux
+func (suite *UserOverridesDisabledTestSuite) SetupTest() {
+
+	mux := chi.NewMux()
+	userAPI := new(DisableUserOverrideHandler)
+
+	mux.Put("/experiments/{experimentKey}", userAPI.SetForcedVariation)
+	mux.Delete("/experiments/{experimentKey}", userAPI.RemoveForcedVariation)
+
+	suite.mux = mux
+}
+
+func (suite *UserOverridesDisabledTestSuite) TestSetForcedVariation() {
+
+	override := &UserOverrideBody{VariationKey: "variation_enabled"}
+	body, err := json.Marshal(override)
+	suite.NoError(err)
+
+	req := httptest.NewRequest("PUT", "/experiments/feature_key", bytes.NewBuffer(body))
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusForbidden, rec.Code)
+
+	response := string(rec.Body.Bytes())
+	suite.Equal("Overrides not enabled\n", response)
+
+}
+func (suite *UserOverridesDisabledTestSuite) TestRemoveForcedVariation() {
+	req := httptest.NewRequest("DELETE", "/experiments/feature_key", nil)
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusForbidden, rec.Code)
+
+	response := string(rec.Body.Bytes())
+	suite.Equal("Overrides not enabled\n", response)
+}
+
+func TestUserOverrideDisabledTestSuite(t *testing.T) {
+	suite.Run(t, new(UserOverridesDisabledTestSuite))
+}

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -52,13 +52,13 @@ func NewDefaultAPIRouter(optlyCache optimizely.Cache, conf config.APIConfig, met
 	authProvider := middleware.NewAuth(&conf.Auth)
 
 	var notificationsAPI handlers.NotificationAPI
-	notificationsAPI = handlers.NewDisableNotificationHandler()
+	notificationsAPI = handlers.NewDisabledNotificationHandler()
 	if conf.EnableNotifications {
 		notificationsAPI = handlers.NewNotificationHandler()
 	}
 
 	var userOverrideAPI handlers.UserOverrideAPI
-	userOverrideAPI = new(handlers.DisableUserOverrideHandler)
+	userOverrideAPI = new(handlers.DisabledUserOverrideHandler)
 	if conf.EnableOverrides {
 		userOverrideAPI = new(handlers.UserOverrideHandler)
 	}

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -72,6 +72,7 @@ func (suite *APIV1TestSuite) SetupTest() {
 		middleware:      &MockOptlyMiddleware{},
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
+		enableOverrides: true,
 	}
 
 	suite.mux = NewAPIV1Router(opts)

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -101,6 +101,34 @@ func (suite *APIV1TestSuite) TestOverride() {
 	}
 }
 
+func (suite *APIV1TestSuite) TestDisabledOverride() {
+
+	route := struct {
+		method string
+		path   string
+	}{"POST", "override"}
+
+	opts := &APIV1Options{
+		maxConns:        1,
+		middleware:      &MockOptlyMiddleware{},
+		handlers:        MockHandlers{},
+		metricsRegistry: metricsRegistry,
+		enableOverrides: false,
+	}
+
+	mux := NewAPIV1Router(opts)
+
+	req := httptest.NewRequest(route.method, "/v1/"+route.path, nil)
+	rec := httptest.NewRecorder()
+	mux.ServeHTTP(rec, req)
+	suite.Equal(http.StatusForbidden, rec.Code)
+
+	// Unmarshal response
+	response := string(rec.Body.Bytes())
+	suite.Equal("Overrides not enabled\n", response)
+
+}
+
 func TestAPIV1TestSuite(t *testing.T) {
 	suite.Run(t, new(APIV1TestSuite))
 }


### PR DESCRIPTION
## Summary
- disable /notifications and /overrides by default
- allow them to be enabled via configuration