### PR TITLE
feat: Add blacklist for crypto cyphers

### DIFF
--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -39,7 +39,7 @@ func assertServer(t *testing.T, actual config.ServerConfig) {
 	assert.Equal(t, 10*time.Second, actual.WriteTimeout)
 	assert.Equal(t, "keyfile", actual.KeyFile)
 	assert.Equal(t, "certfile", actual.CertFile)
-	assert.Equal(t, []uint16{0xc00a, 0xc011}, actual.DisabledCiphers)
+	assert.Equal(t, []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}, actual.DisabledCiphers)
 }
 
 func assertLog(t *testing.T, actual config.LogConfig) {
@@ -112,7 +112,7 @@ func TestViperProps(t *testing.T) {
 	v.Set("server.writetimeout", 10*time.Second)
 	v.Set("server.certfile", "certfile")
 	v.Set("server.keyfile", "keyfile")
-	v.Set("server.disabledciphers", "0xc00a,0xc011")
+	v.Set("server.disabledciphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
 
 	v.Set("log.pretty", true)
 	v.Set("log.level", "debug")
@@ -169,7 +169,7 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_SERVER_WRITETIMEOUT", "10s")
 	_ = os.Setenv("OPTIMIZELY_SERVER_CERTFILE", "certfile")
 	_ = os.Setenv("OPTIMIZELY_SERVER_KEYFILE", "keyfile")
-	_ = os.Setenv("OPTIMIZELY_SERVER_DISABLEDCIPHERS", "0xc00a,0xc011")
+	_ = os.Setenv("OPTIMIZELY_SERVER_DISABLEDCIPHERS", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
 
 	_ = os.Setenv("OPTIMIZELY_LOG_PRETTY", "true")
 	_ = os.Setenv("OPTIMIZELY_LOG_LEVEL", "debug")

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -11,8 +11,8 @@ server:
   keyfile: "keyfile"
   certfile: "certfile"
   disabledciphers:
-    - 0xc00a
-    - 0xc011
+    - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
+    - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
 log:
   pretty: true
   level: debug

--- a/config/config.go
+++ b/config/config.go
@@ -60,7 +60,7 @@ func NewDefaultConfig() *AgentConfig {
 			WriteTimeout:    10 * time.Second,
 			CertFile:        "",
 			KeyFile:         "",
-			DisabledCiphers: make([]uint16, 0),
+			DisabledCiphers: make([]string, 0),
 		},
 		Webhook: WebhookConfig{
 			Port: "8085",
@@ -105,7 +105,7 @@ type ServerConfig struct {
 	WriteTimeout    time.Duration `json:"writetimeout"`
 	CertFile        string        `json:"certfile"`
 	KeyFile         string        `json:"keyfile"`
-	DisabledCiphers []uint16      `json:"disabledciphers"`
+	DisabledCiphers []string      `json:"disabledciphers"`
 }
 
 // APIConfig holds the REST API configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -34,7 +34,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 10*time.Second, conf.Server.WriteTimeout)
 	assert.Equal(t, "", conf.Server.KeyFile)
 	assert.Equal(t, "", conf.Server.CertFile)
-	assert.Equal(t, []uint16{}, conf.Server.DisabledCiphers)
+	assert.Equal(t, []string{}, conf.Server.DisabledCiphers)
 
 	assert.False(t, conf.Log.Pretty)
 	assert.Equal(t, "info", conf.Log.Level)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -127,9 +127,7 @@ func blacklistCiphers(blacklist []string) []uint16 {
 	ciphers := makeDefaultCiphers()
 
 	for _, disabledCipher := range blacklist {
-		if _, ok := ciphers[disabledCipher]; ok {
-			delete(ciphers, disabledCipher)
-		}
+		delete(ciphers, disabledCipher)
 	}
 
 	modifiedCiphers := []uint16{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -96,13 +96,8 @@ func makeTLSConfig(conf config.ServerConfig) (*tls.Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	defaultCiphers := []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	}
-	ciphers := blacklistCiphers(conf.DisabledCiphers, defaultCiphers)
+
+	ciphers := blacklistCiphers(conf.DisabledCiphers)
 
 	return &tls.Config{
 		PreferServerCipherSuites: true,
@@ -117,22 +112,30 @@ func makeTLSConfig(conf config.ServerConfig) (*tls.Config, error) {
 	}, nil
 }
 
-func blacklistCiphers(blacklist, defaultCiphers []uint16) []uint16 {
+func makeDefaultCiphers() map[string]uint16 {
 
-	modifiedCiphers := []uint16{}
-	cipherInBlacklist := func(a []uint16, x uint16) bool {
-		for _, n := range a {
-			if x == n {
-				return true
-			}
+	return map[string]uint16{
+		"TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384": tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384":   tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256": tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256":   tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+	}
+}
+
+func blacklistCiphers(blacklist []string) []uint16 {
+
+	ciphers := makeDefaultCiphers()
+
+	for _, disabledCipher := range blacklist {
+		if _, ok := ciphers[disabledCipher]; ok {
+			delete(ciphers, disabledCipher)
 		}
-		return false
 	}
 
-	for _, cipher := range defaultCiphers {
-		if !cipherInBlacklist(blacklist, cipher) {
-			modifiedCiphers = append(modifiedCiphers, cipher)
-		}
+	modifiedCiphers := []uint16{}
+
+	for _, goodCipher := range ciphers {
+		modifiedCiphers = append(modifiedCiphers, goodCipher)
 	}
 
 	return modifiedCiphers

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -104,19 +104,13 @@ func TestTSLServerConfigs(t *testing.T) {
 
 func TestBlacklistCiphers(t *testing.T) {
 
-	blacklist := []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA,
+	blacklist := []string{
+		"TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256",
+		"TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA",
 	}
 
-	defaultCiphers := []uint16{
-		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
-		tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
-		tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
-	}
-	ciphers := blacklistCiphers(blacklist, defaultCiphers)
+	ciphers := blacklistCiphers(blacklist)
 
 	expectedCiphers := []uint16{
 		tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384,


### PR DESCRIPTION
## Summary
- after the review, I am changing the cipher blacklist to a string type, instead of hexadecimal value.
- since ciphers are defined as uint16 in go language, I have created an internal map of string to uint16