### PR TITLE
Handle invalid filter types.

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -64,6 +64,8 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/Decision'
+        '400':
+          description: Bad request, invalid parameters
         '403':
           $ref: '#/components/responses/Forbidden'
       requestBody:

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -21,11 +21,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/optimizely/go-sdk/pkg/config"
-
 	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely"
 
+	"github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/entities"
 
 	"github.com/go-chi/render"

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -59,26 +59,26 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 	decisions := make([]*optimizely.Decision, 0, len(oConf.ExperimentsMap)+len(oConf.FeaturesMap))
 	disableTracking := query.Get("disableTracking") == "true"
 
-	km := make(keyMap)
-	err = parseTypeParameter(query["type"], oConf, km)
+	kmap := make(keyMap)
+	err = parseTypeParameter(query["type"], oConf, kmap)
 	if err != nil {
 		RenderError(err, http.StatusBadRequest, w, r)
 		return
 	}
 
-	err = parseExperimentKeys(query["experimentKey"], oConf, km)
+	err = parseExperimentKeys(query["experimentKey"], oConf, kmap)
 	if err != nil {
 		RenderError(err, http.StatusNotFound, w, r)
 		return
 	}
 
-	err = parseFeatureKeys(query["featureKey"], oConf, km)
+	err = parseFeatureKeys(query["featureKey"], oConf, kmap)
 	if err != nil {
 		RenderError(err, http.StatusNotFound, w, r)
 		return
 	}
 
-	for key, value := range km {
+	for key, value := range kmap {
 		var d *optimizely.Decision
 
 		switch value {
@@ -104,42 +104,42 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, decisions)
 }
 
-func parseExperimentKeys(keys []string, oConf *config.OptimizelyConfig, km keyMap) error {
+func parseExperimentKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap) error {
 	for _, key := range keys {
 		_, ok := oConf.ExperimentsMap[key]
 		if !ok {
 			return fmt.Errorf("experimentKey not-found")
 		}
 
-		km[key] = "experiment"
+		kmap[key] = "experiment"
 	}
 
 	return nil
 }
 
-func parseFeatureKeys(keys []string, oConf *config.OptimizelyConfig, km keyMap) error {
+func parseFeatureKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap) error {
 	for _, key := range keys {
 		_, ok := oConf.FeaturesMap[key]
 		if !ok {
 			return fmt.Errorf("featureKey not-found")
 		}
 
-		km[key] = "feature"
+		kmap[key] = "feature"
 	}
 
 	return nil
 }
 
-func parseTypeParameter(types []string, oConf *config.OptimizelyConfig, km keyMap) error {
+func parseTypeParameter(types []string, oConf *config.OptimizelyConfig, kmap keyMap) error {
 	for _, filterType := range types {
 		switch filterType {
 		case "experiment":
 			for key := range oConf.ExperimentsMap {
-				km[key] = "experiment"
+				kmap[key] = "experiment"
 			}
 		case "feature":
 			for key := range oConf.FeaturesMap {
-				km[key] = "feature"
+				kmap[key] = "feature"
 			}
 		default:
 			return fmt.Errorf(`type "%s" not supported`, filterType)

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -69,6 +69,9 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 			for key := range oConf.FeaturesMap {
 				featureSet[key] = struct{}{}
 			}
+		default:
+			RenderError(fmt.Errorf(`type "%s" not supported`, filterType), http.StatusBadRequest, w, r)
+			return
 		}
 	}
 

--- a/pkg/handlers/activate_test.go
+++ b/pkg/handlers/activate_test.go
@@ -403,6 +403,20 @@ func (suite *ActivateTestSuite) TestEnabledFilter() {
 	}
 }
 
+func (suite *ActivateTestSuite) TestInvalidFilter() {
+	req := httptest.NewRequest("POST", "/activate?type=invalid", nil)
+	rec := httptest.NewRecorder()
+	suite.mux.ServeHTTP(rec, req)
+
+	suite.Equal(http.StatusBadRequest, rec.Code)
+
+	// Unmarshal response
+	var actual ErrorResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &actual)
+	suite.NoError(err)
+	suite.Equal(`type "invalid" not supported`, actual.Error)
+}
+
 func (suite *ActivateTestSuite) assertError(rec *httptest.ResponseRecorder, msg string, code int) {
 	assertError(suite.T(), rec, msg, code)
 }

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -190,8 +190,8 @@ func (c *OptlyClient) RemoveForcedVariation(experimentKey, userID string) error 
 
 // ActivateFeature activates a feature for a given user by getting the feature enabled status and all
 // associated variables
-func (c *OptlyClient) ActivateFeature(feature *optimizelyconfig.OptimizelyFeature, uc entities.UserContext, disableTracking bool) (*Decision, error) {
-	enabled, variables, err := c.GetAllFeatureVariables(feature.Key, uc)
+func (c *OptlyClient) ActivateFeature(key string, uc entities.UserContext, disableTracking bool) (*Decision, error) {
+	enabled, variables, err := c.GetAllFeatureVariables(key, uc)
 	if err != nil {
 		return &Decision{}, err
 	}
@@ -199,7 +199,7 @@ func (c *OptlyClient) ActivateFeature(feature *optimizelyconfig.OptimizelyFeatur
 	// HACK - Triggers impression events when applicable. This is not
 	// ideal since we're making TWO decisions for each feature now. TODO OASIS-5549
 	if !disableTracking {
-		_, tErr := c.IsFeatureEnabled(feature.Key, uc)
+		_, tErr := c.IsFeatureEnabled(key, uc)
 		if tErr != nil {
 			return &Decision{}, tErr
 		}
@@ -207,7 +207,7 @@ func (c *OptlyClient) ActivateFeature(feature *optimizelyconfig.OptimizelyFeatur
 
 	// TODO add experiment and variation keys where applicable
 	dec := &Decision{
-		FeatureKey: feature.Key,
+		FeatureKey: key,
 		Variables:  variables,
 		Enabled:    enabled,
 		Type:       "feature",
@@ -217,21 +217,21 @@ func (c *OptlyClient) ActivateFeature(feature *optimizelyconfig.OptimizelyFeatur
 }
 
 // ActivateExperiment activates an experiment
-func (c *OptlyClient) ActivateExperiment(experiment *optimizelyconfig.OptimizelyExperiment, uc entities.UserContext, disableTracking bool) (*Decision, error) {
+func (c *OptlyClient) ActivateExperiment(key string, uc entities.UserContext, disableTracking bool) (*Decision, error) {
 	var variation string
 	var err error
 
 	if disableTracking {
-		variation, err = c.GetVariation(experiment.Key, uc)
+		variation, err = c.GetVariation(key, uc)
 	} else {
-		variation, err = c.Activate(experiment.Key, uc)
+		variation, err = c.Activate(key, uc)
 	}
 	if err != nil {
 		return &Decision{}, err
 	}
 
 	dec := &Decision{
-		ExperimentKey: experiment.Key,
+		ExperimentKey: key,
 		VariationKey:  variation,
 		Enabled:       variation != "",
 		Type:          "experiment",

--- a/pkg/optimizely/client_test.go
+++ b/pkg/optimizely/client_test.go
@@ -267,7 +267,7 @@ func (suite *ClientTestSuite) TestActivateFeature() {
 
 	// Response should be the same regardless of the flag
 	for _, flag := range []bool{true, false} {
-		actual, err := suite.optlyClient.ActivateFeature(&feature, entities.UserContext{ID: "testUser"}, flag)
+		actual, err := suite.optlyClient.ActivateFeature(feature.Key, entities.UserContext{ID: "testUser"}, flag)
 		suite.NoError(err)
 		suite.Equal(expected, actual)
 	}
@@ -292,7 +292,7 @@ func (suite *ClientTestSuite) TestActivateExperiment() {
 
 	// Response should be the same regardless of the flag
 	for _, flag := range []bool{true, false} {
-		actual, err := suite.optlyClient.ActivateExperiment(&experiment, entities.UserContext{ID: "testUser"}, flag)
+		actual, err := suite.optlyClient.ActivateExperiment(experiment.Key, entities.UserContext{ID: "testUser"}, flag)
 		suite.NoError(err)
 		suite.Equal(expected, actual)
 	}


### PR DESCRIPTION
## Summary
* Return error if `?type=` parameter is not supported

Current behavior is to ignore the unknown type filter.