### PR TITLE
Fix spec to use singular enums.

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -133,8 +133,8 @@ components:
       schema:
         type: string
         enum:
-          - features
-          - experiments
+          - feature
+          - experiment
   requestBodies:
     ActivateContext:
       required: true


### PR DESCRIPTION
## Summary
* Fix spec to use singular type enum

The implementation differed from the documented spec. Singular is more semantic since it matches the `type` attribute in the response entities.