### PR TITLE
Add /track 400 response to the spec.

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -35,6 +35,8 @@ paths:
       responses:
         '204':
           description: No content, event received
+        '400':
+          description: Missing required parameters
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':


### PR DESCRIPTION
## Summary
* Add 400 - Bad Request to API spec

`eventKey` is a required parameter when calling `/track`. Omitting the value or key should return a 400. This is distinct from a 404 response which indicates that a key was supplied, but it does not exist as part of the project.