### PR TITLE
Throw 404 if eventKey not part of the project

### DIFF
--- a/pkg/handlers/track.go
+++ b/pkg/handlers/track.go
@@ -73,7 +73,7 @@ func TrackEvent(w http.ResponseWriter, r *http.Request) {
 
 	err = optlyClient.Track(eventKey, uc, body.EventTags)
 	if err != nil {
-		RenderError(err, http.StatusBadRequest, w, r)
+		RenderError(err, http.StatusInternalServerError, w, r)
 		return
 	}
 

--- a/pkg/handlers/track_test.go
+++ b/pkg/handlers/track_test.go
@@ -182,7 +182,7 @@ func (suite *TrackTestSuite) TestTrackEventParamError() {
 		code    int
 		message string
 	}{
-		{"?eventKey=invalid", http.StatusNotFound, "Event with key invalid not found"},
+		{"?eventKey=invalid", http.StatusNotFound, `event with key "invalid" not found`},
 		{"?eventKey=", http.StatusBadRequest, "missing required path parameter: eventKey"},
 		{"", http.StatusBadRequest, "missing required path parameter: eventKey"},
 	}

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -32,7 +32,7 @@ var errNullOptimizelyConfig = errors.New("optimizely config is null")
 // OptlyClient wraps an instance of the OptimizelyClient to provide higher level functionality
 type OptlyClient struct {
 	*optimizelyclient.OptimizelyClient
-	ConfigManager    *optimizelyconfig.PollingProjectConfigManager
+	ConfigManager    SyncedConfigManager
 	ForcedVariations *decision.MapExperimentOverridesStore
 }
 

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -29,6 +29,9 @@ import (
 
 var errNullOptimizelyConfig = errors.New("optimizely config is null")
 
+// ErrEventKeyDoesNotExist signals that the eventKey does not exist as part of the current configuration
+var ErrEventKeyDoesNotExist = errors.New("eventKey does not exist")
+
 // OptlyClient wraps an instance of the OptimizelyClient to provide higher level functionality
 type OptlyClient struct {
 	*optimizelyclient.OptimizelyClient
@@ -116,6 +119,20 @@ func (c *OptlyClient) UpdateConfig() {
 // TrackEventWithContext calls the OptimizelyClient Track method with the current OptlyContext.
 func (c *OptlyClient) TrackEventWithContext(eventKey string, ctx *OptlyContext, eventTags map[string]interface{}) error {
 	return c.Track(eventKey, *ctx.UserContext, eventTags)
+}
+
+// TrackEvent checks for the existence of the event before calling the OptimizelyClient Track method
+func (c *OptlyClient) TrackEvent(eventKey string, uc entities.UserContext, eventTags map[string]interface{}) error {
+	pc, err := c.ConfigManager.GetConfig()
+	if err != nil {
+		return err
+	}
+
+	if _, err = pc.GetEventByKey(eventKey); err != nil {
+		return ErrEventKeyDoesNotExist
+	}
+
+	return c.Track(eventKey, uc, eventTags)
 }
 
 // GetFeatureWithContext calls the OptimizelyClient with the current OptlyContext

--- a/pkg/optimizely/interface.go
+++ b/pkg/optimizely/interface.go
@@ -17,7 +17,18 @@
 // Package optimizely wraps the Optimizely SDK
 package optimizely
 
+import (
+	optimizelyconfig "github.com/optimizely/go-sdk/pkg/config"
+)
+
 // Cache defines a basic interface for retrieving an instance of the OptlyClient keyed off of the SDK Key
 type Cache interface {
 	GetClient(sdkKey string) (*OptlyClient, error)
+}
+
+// SyncedConfigManager has the basic ConfigManager methods plus the SyncConfig method to trigger immediate updates
+type SyncedConfigManager interface {
+	GetConfig() (optimizelyconfig.ProjectConfig, error)
+	GetOptimizelyConfig() *optimizelyconfig.OptimizelyConfig
+	SyncConfig()
 }


### PR DESCRIPTION
## Summary
* Create `SycnedConfigManager` interface for OptlyClient
* Check the OptlyClient config manager for event key prior to calling track

This is a bit of a workaround since the native SDK swallows tracking errors related to event key existence and events are not part of the `OptimizelyConfig` object. We could have opened up the SDK a bit, but that would have amounted to a breaking change if we started to propagate errors (which is arguably the right approach). That being said, for track in particular I want to set us up to remove the event creation constraint within the application in which case we'd simply remove this code as 404 will no longer be applicable.