### PR TITLE
feat: Connect access token creation handler and auth middleware in V1 API

### DIFF
--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -156,9 +156,8 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 		maxConns:        opt.maxConns,
 		enableOverrides: opt.enableOverrides,
 		middleware:      opt.middleware,
-		handlers:        new(defaultHandlers),
+		handlers:        newDefaultHandlers(opt.oAuthHandler),
 		metricsRegistry: opt.metricsRegistry,
-		oAuthHandler:    opt.oAuthHandler,
 	}
 
 	r.Group(func(r chi.Router) { WithAPIV1Router(spec, r) })

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -158,6 +158,7 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 		middleware:      opt.middleware,
 		handlers:        new(defaultHandlers),
 		metricsRegistry: opt.metricsRegistry,
+		oAuthHandler:    opt.oAuthHandler,
 	}
 
 	r.Group(func(r chi.Router) { WithAPIV1Router(spec, r) })

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -158,6 +158,7 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 		middleware:      opt.middleware,
 		handlers:        newDefaultHandlers(opt.oAuthHandler),
 		metricsRegistry: opt.metricsRegistry,
+		oAuthMiddleware: opt.oAuthMiddleware,
 	}
 
 	r.Group(func(r chi.Router) { WithAPIV1Router(spec, r) })

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -156,8 +156,9 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 		maxConns:        opt.maxConns,
 		enableOverrides: opt.enableOverrides,
 		middleware:      opt.middleware,
-		handlers:        newDefaultHandlers(opt.oAuthHandler),
+		handlers:        new(defaultHandlers),
 		metricsRegistry: opt.metricsRegistry,
+		oAuthHandler:    opt.oAuthHandler,
 		oAuthMiddleware: opt.oAuthMiddleware,
 	}
 

--- a/pkg/routers/api_v1.go
+++ b/pkg/routers/api_v1.go
@@ -38,8 +38,8 @@ type APIV1Options struct {
 	middleware      middleware.OptlyMiddleware
 	handlers        apiHandlers
 	metricsRegistry *metrics.Registry
-	oAuthHandler    *handlers.OAuthHandler
-	oAuthMiddleware middleware.Auth
+	oAuthHandler    apiOAuthHandler
+	oAuthMiddleware apiOAuthMiddleware
 }
 
 // Define an interface to facilitate testing
@@ -66,6 +66,14 @@ func (d defaultHandlers) trackEvent(w http.ResponseWriter, r *http.Request) {
 
 func (d defaultHandlers) override(w http.ResponseWriter, r *http.Request) {
 	handlers.Override(w, r)
+}
+
+type apiOAuthHandler interface {
+	CreateAPIAccessToken(w http.ResponseWriter, r *http.Request)
+}
+
+type apiOAuthMiddleware interface {
+	AuthorizeAPI(next http.Handler) http.Handler
 }
 
 // NewDefaultAPIV1Router creates a new router with the default backing optimizely.Cache

--- a/pkg/routers/api_v1.go
+++ b/pkg/routers/api_v1.go
@@ -127,6 +127,7 @@ func WithAPIV1Router(opt *APIV1Options, r chi.Router) {
 		r.With(activateTimer, opt.oAuthMiddleware.AuthorizeAPI).Post("/activate", opt.handlers.activate)
 		r.With(trackTimer, opt.oAuthMiddleware.AuthorizeAPI).Post("/track", opt.handlers.trackEvent)
 		r.With(overrideTimer, opt.oAuthMiddleware.AuthorizeAPI).Post("/override", overrideHandler)
-		r.With(createAccesstokenTimer).Post("/oauth/token", opt.oAuthHandler.CreateAPIAccessToken)
 	})
+
+	r.With(createAccesstokenTimer).Post("/oauth/api/token", opt.oAuthHandler.CreateAPIAccessToken)
 }

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -120,7 +120,6 @@ func (suite *APIV1TestSuite) TestOverride() {
 		suite.Equal(route.path, rec.Header().Get(methodHeaderKey))
 		suite.Equal("mockMiddleware", rec.Header().Get(middlewareHeaderKey))
 	}
-
 }
 
 func (suite *APIV1TestSuite) TestDisabledOverride() {

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -18,6 +18,7 @@
 package routers
 
 import (
+	"github.com/optimizely/agent/pkg/handlers"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -73,6 +74,11 @@ func (suite *APIV1TestSuite) SetupTest() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: true,
+		oAuthHandler: handlers.NewOAuthHandler(&config.ServiceAuthConfig{
+			Clients:    []config.OAuthClientCredentials{},
+			HMACSecret: "",
+			TTL:        0,
+		}),
 	}
 
 	suite.mux = NewAPIV1Router(opts)
@@ -114,6 +120,11 @@ func (suite *APIV1TestSuite) TestDisabledOverride() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: false,
+		oAuthHandler: handlers.NewOAuthHandler(&config.ServiceAuthConfig{
+			Clients:    []config.OAuthClientCredentials{},
+			HMACSecret: "",
+			TTL:        0,
+		}),
 	}
 
 	mux := NewAPIV1Router(opts)

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -18,6 +18,7 @@
 package routers
 
 import (
+	"github.com/optimizely/agent/pkg/handlers"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -78,6 +79,11 @@ func (suite *APIV1TestSuite) SetupTest() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: true,
+		oAuthHandler: handlers.NewOAuthHandler(&config.ServiceAuthConfig{
+			Clients:    []config.OAuthClientCredentials{},
+			HMACSecret: "",
+			TTL:        0,
+		}),
 		oAuthMiddleware: middleware.Auth{Verifier: middleware.NoAuth{}},
 	}
 
@@ -94,7 +100,6 @@ func (suite *APIV1TestSuite) TestOverride() {
 		{"POST", "activate"},
 		{"POST", "track"},
 		{"POST", "override"},
-		{"POST", "oauth/token"},
 	}
 
 	for _, route := range routes {
@@ -121,6 +126,11 @@ func (suite *APIV1TestSuite) TestDisabledOverride() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: false,
+		oAuthHandler: handlers.NewOAuthHandler(&config.ServiceAuthConfig{
+			Clients:    []config.OAuthClientCredentials{},
+			HMACSecret: "",
+			TTL:        0,
+		}),
 		oAuthMiddleware: middleware.Auth{Verifier: middleware.NoAuth{}},
 	}
 

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -153,7 +153,7 @@ func (suite *APIV1TestSuite) TestDisabledOverride() {
 }
 
 func (suite *APIV1TestSuite) TestCreateAccessToken() {
-	req := httptest.NewRequest("POST", "/v1/oauth/token", nil)
+	req := httptest.NewRequest("POST", "/oauth/api/token", nil)
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
 	suite.Equal(http.StatusOK, rec.Code)

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -18,7 +18,6 @@
 package routers
 
 import (
-	"github.com/optimizely/agent/pkg/handlers"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -58,6 +57,10 @@ func (m MockHandlers) override(w http.ResponseWriter, r *http.Request) {
 	w.Header().Add(methodHeaderKey, "override")
 }
 
+func (m MockHandlers) createAccessToken(w http.ResponseWriter, r *http.Request) {
+	w.Header().Add(methodHeaderKey, "oauth/token")
+}
+
 type APIV1TestSuite struct {
 	suite.Suite
 	tc  *optimizelytest.TestClient
@@ -74,11 +77,6 @@ func (suite *APIV1TestSuite) SetupTest() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: true,
-		oAuthHandler: handlers.NewOAuthHandler(&config.ServiceAuthConfig{
-			Clients:    []config.OAuthClientCredentials{},
-			HMACSecret: "",
-			TTL:        0,
-		}),
 	}
 
 	suite.mux = NewAPIV1Router(opts)
@@ -94,6 +92,7 @@ func (suite *APIV1TestSuite) TestOverride() {
 		{"POST", "activate"},
 		{"POST", "track"},
 		{"POST", "override"},
+		{"POST", "oauth/token"},
 	}
 
 	for _, route := range routes {
@@ -120,11 +119,6 @@ func (suite *APIV1TestSuite) TestDisabledOverride() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: false,
-		oAuthHandler: handlers.NewOAuthHandler(&config.ServiceAuthConfig{
-			Clients:    []config.OAuthClientCredentials{},
-			HMACSecret: "",
-			TTL:        0,
-		}),
 	}
 
 	mux := NewAPIV1Router(opts)

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stretchr/testify/suite"
 
 	"github.com/optimizely/agent/config"
+	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely"
 	"github.com/optimizely/agent/pkg/optimizely/optimizelytest"
 )
@@ -77,6 +78,7 @@ func (suite *APIV1TestSuite) SetupTest() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: true,
+		oAuthMiddleware: middleware.Auth{Verifier: middleware.NoAuth{}},
 	}
 
 	suite.mux = NewAPIV1Router(opts)
@@ -119,6 +121,7 @@ func (suite *APIV1TestSuite) TestDisabledOverride() {
 		handlers:        MockHandlers{},
 		metricsRegistry: metricsRegistry,
 		enableOverrides: false,
+		oAuthMiddleware: middleware.Auth{Verifier: middleware.NoAuth{}},
 	}
 
 	mux := NewAPIV1Router(opts)


### PR DESCRIPTION
## Summary
This makes the existing OAuth functionality available in the V1 API service:
- Exposed token issuer endpoint at `POST /v1/oauth/token`
- Connected token authorization middleware to `v1/config`, `v1/activate`, `v1/track`, and `v1/override`
## Test Plan
- Manually tested
- Updated V1 router unit tests
- Existing tests for old API and Admin services should pass
## JIRA
https://optimizely.atlassian.net/browse/OASIS-6028