### PR TITLE
Refactor and document client config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,17 +68,18 @@ Below is a comprehensive list of available configuration properties.
 |author|OPTIMIZELY_AUTHOR|Agent author. Default: Optimizely Inc.|
 |name|OPTIMIZELY_NAME|Agent name. Default: optimizely|
 |version|OPTIMIZELY_VERSION|Agent version. Default: `git describe --tags`|
-|sdkkeys|OPTIMIZELY_SDK_KEYS|List of SDK keys used to initialize on startup|
-|processor.batchSize|OPTIMIZELY_PROCESSOR_BATCHSIZE|The number of events in a batch. Default: 10|
-|processor.queueSize|OPTIMIZELY_PROCESSOR_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
-|processor.flushInterval|OPTIMIZELY_PROCESSOR_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
+|sdkKeys|OPTIMIZELY_SDK_KEYS|List of SDK keys used to initialize on startup|
+|client.pollingInterval|OPTIMIZELY_CLIENT_POLLINGINTERVAL|The time between successive polls for updated project configuration. Default: 1m|
+|client.batchSize|OPTIMIZELY_CLIENT_BATCHSIZE|The number of events in a batch. Default: 10|
+|client.queueSize|OPTIMIZELY_CLIENT_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
+|client.flushInterval|OPTIMIZELY_CLIENT_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
 |log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|
 |log.pretty|OPTIMIZELY_LOG_PRETTY|Flag used to set colorized console output as opposed to structured json logs. Default: false|
-|server.readtimeout|OPTIMIZELY_SERVER_READTIMEOUT|The maximum duration for reading the entire body. Default: “5s”|
-|server.writetimeout|OPTIMIZELY_SERVER_WRITETIMEOUT|The maximum duration before timing out writes of the response. Default: “10s”|
+|server.readTimeout|OPTIMIZELY_SERVER_READTIMEOUT|The maximum duration for reading the entire body. Default: “5s”|
+|server.writeTimeout|OPTIMIZELY_SERVER_WRITETIMEOUT|The maximum duration before timing out writes of the response. Default: “10s”|
 |admin.port|OPTIMIZELY_ADMIN_PORT|Admin listener port. Default: 8088|
 |api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
-|api.maxconns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
+|api.maxConns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
 |webhook.port|OPTIMIZELY_WEBHOOK_PORT|Webhook listener port: Default: 8085|
 |webhook.projects.<*projectId*>.sdkKeys|N/A|Comma delimited list of SDK Keys applicable to the respective projectId|
 |webhook.projects.<*projectId*>.secret|N/A|Webhook secret used to validate webhook requests originating from the respective projectId|

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -104,7 +104,7 @@ func main() {
 
 	ctx, cancel := context.WithCancel(context.Background()) // Create default service context
 	sg := server.NewGroup(ctx, conf.Server)                 // Create a new server group to manage the individual http listeners
-	optlyCache := optimizely.NewCache(ctx, conf.Processor, sdkMetricsRegistry)
+	optlyCache := optimizely.NewCache(ctx, conf.Client, sdkMetricsRegistry)
 	optlyCache.Init(conf.SDKKeys)
 
 	// goroutine to check for signals to gracefully shutdown listeners

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -42,6 +42,13 @@ func assertServer(t *testing.T, actual config.ServerConfig) {
 	assert.Equal(t, []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256", "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"}, actual.DisabledCiphers)
 }
 
+func assertClient(t *testing.T, actual config.ClientConfig) {
+	assert.Equal(t, 10*time.Second, actual.PollingInterval)
+	assert.Equal(t, 1, actual.BatchSize)
+	assert.Equal(t, 10, actual.QueueSize)
+	assert.Equal(t, 1*time.Minute, actual.FlushInterval)
+}
+
 func assertLog(t *testing.T, actual config.LogConfig) {
 	assert.True(t, actual.Pretty)
 	assert.Equal(t, "debug", actual.Level)
@@ -97,6 +104,7 @@ func TestViperYaml(t *testing.T) {
 
 	assertRoot(t, actual)
 	assertServer(t, actual.Server)
+	assertClient(t, actual.Client)
 	assertLog(t, actual.Log)
 	assertAdmin(t, actual.Admin)
 	assertAdminAuth(t, actual.Admin.Auth)
@@ -113,18 +121,23 @@ func TestViperProps(t *testing.T) {
 	v.Set("name", "optimizely")
 	v.Set("sdkkeys", []string{"ddd", "eee", "fff"})
 
-	v.Set("server.readtimeout", 5*time.Second)
-	v.Set("server.writetimeout", 10*time.Second)
-	v.Set("server.certfile", "certfile")
-	v.Set("server.keyfile", "keyfile")
-	v.Set("server.disabledciphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+	v.Set("server.readTimeout", 5*time.Second)
+	v.Set("server.writeTimeout", 10*time.Second)
+	v.Set("server.certFile", "certfile")
+	v.Set("server.keyFile", "keyfile")
+	v.Set("server.disabledCiphers", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+
+	v.Set("client.pollingInterval", 10*time.Second)
+	v.Set("client.batchSize", 1)
+	v.Set("client.queueSize", 10)
+	v.Set("client.flushInterval", 1*time.Minute)
 
 	v.Set("log.pretty", true)
 	v.Set("log.level", "debug")
 
 	v.Set("admin.port", "3002")
 	v.Set("admin.auth.ttl", "30m")
-	v.Set("admin.auth.hmacsecret", "efgh")
+	v.Set("admin.auth.hmacSecret", "efgh")
 	v.Set("admin.auth.clients", []map[string]string{
 		{
 			"id":     "clientid2",
@@ -132,12 +145,12 @@ func TestViperProps(t *testing.T) {
 		},
 	})
 
-	v.Set("api.maxconns", 100)
-	v.Set("api.enablenotifications", true)
-	v.Set("api.enableoverrides", true)
+	v.Set("api.maxConns", 100)
+	v.Set("api.enableNotifications", true)
+	v.Set("api.enableOverrides", true)
 	v.Set("api.port", "3000")
 	v.Set("api.auth.ttl", "30m")
-	v.Set("api.auth.hmacsecret", "abcd")
+	v.Set("api.auth.hmacSecret", "abcd")
 	v.Set("api.auth.clients", []map[string]string{
 		{
 			"id":     "clientid1",
@@ -147,17 +160,18 @@ func TestViperProps(t *testing.T) {
 
 	v.Set("webhook.port", "3001")
 	v.Set("webhook.projects.10000.secret", "secret-10000")
-	v.Set("webhook.projects.10000.sdkkeys", []string{"aaa", "bbb", "ccc"})
-	v.Set("webhook.projects.10000.skipsignaturecheck", true)
+	v.Set("webhook.projects.10000.sdkKeys", []string{"aaa", "bbb", "ccc"})
+	v.Set("webhook.projects.10000.skipSignatureCheck", true)
 	v.Set("webhook.projects.20000.secret", "secret-20000")
-	v.Set("webhook.projects.20000.sdkkeys", []string{"xxx", "yyy", "zzz"})
-	v.Set("webhook.projects.20000.skipsignaturecheck", false)
+	v.Set("webhook.projects.20000.sdkKeys", []string{"xxx", "yyy", "zzz"})
+	v.Set("webhook.projects.20000.skipSignatureCheck", false)
 
 	assert.NoError(t, initConfig(v))
 	actual := loadConfig(v)
 
 	assertRoot(t, actual)
 	assertServer(t, actual.Server)
+	assertClient(t, actual.Client)
 	assertLog(t, actual.Log)
 	assertAdmin(t, actual.Admin)
 	assertAdminAuth(t, actual.Admin.Auth)
@@ -177,6 +191,11 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_SERVER_CERTFILE", "certfile")
 	_ = os.Setenv("OPTIMIZELY_SERVER_KEYFILE", "keyfile")
 	_ = os.Setenv("OPTIMIZELY_SERVER_DISABLEDCIPHERS", "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384")
+
+	_ = os.Setenv("OPTIMIZELY_CLIENT_POLLINGINTERVAL", "10s")
+	_ = os.Setenv("OPTIMIZELY_CLIENT_BATCHSIZE", "1")
+	_ = os.Setenv("OPTIMIZELY_CLIENT_QUEUESIZE", "10")
+	_ = os.Setenv("OPTIMIZELY_CLIENT_FLUSHINTERVAL", "1m")
 
 	_ = os.Setenv("OPTIMIZELY_LOG_PRETTY", "true")
 	_ = os.Setenv("OPTIMIZELY_LOG_LEVEL", "debug")
@@ -202,6 +221,7 @@ func TestViperEnv(t *testing.T) {
 
 	assertRoot(t, actual)
 	assertServer(t, actual.Server)
+	assertClient(t, actual.Client)
 	assertLog(t, actual.Log)
 	assertAdmin(t, actual.Admin)
 	assertAPI(t, actual.API)

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -8,14 +8,19 @@ sdkKeys:
 server:
   readTimeout: 5s
   writeTimeout: 10s
-  keyfile: "keyfile"
-  certfile: "certfile"
+  keyFile: "keyfile"
+  certFile: "certfile"
   disabledCiphers:
     - "TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"
     - "TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384"
 log:
   pretty: true
   level: debug
+client:
+  pollingInterval: 10s
+  batchSize: 1
+  queueSize: 10
+  flushInterval: 1m
 admin:
   port: "3002"
   auth:

--- a/config.yaml
+++ b/config.yaml
@@ -30,19 +30,27 @@ log:
 server:
     ## the maximum duration for reading the entire request, including the body.
     ## Value can be set in seconds (e.g. "5s") or milliseconds (e.g. "5000ms")
-    readtimeout: 5s
+    readTimeout: 5s
     ## the maximum duration before timing out writes of the response.
     ## Value can be set in seconds (e.g. "5s") or milliseconds (e.g. "5000ms")
-    writetimeout: 10s
+    writeTimeout: 10s
+    ## the location of the TLS key file
+#    keyFile: <key-file>
+    ## the location of the TLS certificate file
+#    certFile: <cert-file>
 
 ##
 ## api service configuration
 ##
 api:
     ## the maximum number of concurrent requests handled by the api listener
-#    maxconns: 10000
+#    maxConns: 10000
     ## http listener port
     port: "8080"
+    ## set to true to enable subscribing to notifications via an SSE event-stream
+    enableNotifications: false
+    ## set to true to be able to override experiment bucketing. (recommended false in production)
+    enableOverrides: false
 
 ##
 ## admin service configuration
@@ -72,9 +80,11 @@ webhook:
 #            skipSignatureCheck: true
 
 ##
-## event processor configurations
+## optimizely client configurations (options passed to the underlying go-sdk)
 ##
-processor:
+client:
+    ## the time between successive polls for updated project configuration
+    pollingInterval: 1m
     ## the number of events in a batch
     batchSize: 10
     ## the max number of events pending dispatch, setting this too low may result in events being dropped

--- a/config/config.go
+++ b/config/config.go
@@ -52,10 +52,11 @@ func NewDefaultConfig() *AgentConfig {
 			Pretty: false,
 			Level:  "info",
 		},
-		Processor: ProcessorConfig{
-			BatchSize:     10,
-			QueueSize:     1000,
-			FlushInterval: 30 * time.Second,
+		Client: ClientConfig{
+			PollingInterval: 1 * time.Minute,
+			BatchSize:       10,
+			QueueSize:       1000,
+			FlushInterval:   30 * time.Second,
 		},
 		Server: ServerConfig{
 			ReadTimeout:     5 * time.Second,
@@ -80,19 +81,20 @@ type AgentConfig struct {
 
 	SDKKeys []string `yaml:"sdkKeys" json:"sdkKeys"`
 
-	Admin     AdminConfig     `json:"admin"`
-	API       APIConfig       `json:"api"`
-	Log       LogConfig       `json:"log"`
-	Processor ProcessorConfig `json:"processor"`
-	Server    ServerConfig    `json:"server"`
-	Webhook   WebhookConfig   `json:"webhook"`
+	Admin   AdminConfig   `json:"admin"`
+	API     APIConfig     `json:"api"`
+	Log     LogConfig     `json:"log"`
+	Client  ClientConfig  `json:"client"`
+	Server  ServerConfig  `json:"server"`
+	Webhook WebhookConfig `json:"webhook"`
 }
 
-// ProcessorConfig holds the configuration options for the Optimizely Event Processor.
-type ProcessorConfig struct {
-	BatchSize     int           `json:"batchSize" default:"10"`
-	QueueSize     int           `json:"queueSize" default:"1000"`
-	FlushInterval time.Duration `json:"flushInterval" default:"30s"`
+// ClientConfig holds the configuration options for the Optimizely Client.
+type ClientConfig struct {
+	PollingInterval time.Duration `json:"pollingInterval"`
+	BatchSize       int           `json:"batchSize" default:"10"`
+	QueueSize       int           `json:"queueSize" default:"1000"`
+	FlushInterval   time.Duration `json:"flushInterval" default:"30s"`
 }
 
 // LogConfig holds the log configuration
@@ -105,8 +107,8 @@ type LogConfig struct {
 type ServerConfig struct {
 	ReadTimeout     time.Duration `json:"readTimeout"`
 	WriteTimeout    time.Duration `json:"writeTimeout"`
-	CertFile        string        `json:"certfile"`
-	KeyFile         string        `json:"keyfile"`
+	CertFile        string        `json:"certFile"`
+	KeyFile         string        `json:"keyFile"`
 	DisabledCiphers []string      `json:"disabledCiphers"`
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -55,7 +55,8 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, "8085", conf.Webhook.Port)
 	assert.Empty(t, conf.Webhook.Projects)
 
-	assert.Equal(t, 10, conf.Processor.BatchSize)
-	assert.Equal(t, 1000, conf.Processor.QueueSize)
-	assert.Equal(t, 30*time.Second, conf.Processor.FlushInterval)
+	assert.Equal(t, 1*time.Minute, conf.Client.PollingInterval)
+	assert.Equal(t, 10, conf.Client.BatchSize)
+	assert.Equal(t, 1000, conf.Client.QueueSize)
+	assert.Equal(t, 30*time.Second, conf.Client.FlushInterval)
 }

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -89,7 +89,7 @@ func TestCacheTestSuite(t *testing.T) {
 	suite.Run(t, new(CacheTestSuite))
 }
 
-func mockLoader(sdkKey string, conf config.ProcessorConfig, metricsRegistry *MetricsRegistry) (*OptlyClient, error) {
+func mockLoader(sdkKey string, conf config.ClientConfig, metricsRegistry *MetricsRegistry) (*OptlyClient, error) {
 	if sdkKey == "ERROR" {
 		return &OptlyClient{}, fmt.Errorf("Error")
 	}


### PR DESCRIPTION
## Summary
* Rename `processor` config to `client` config
* Add `client.pollingInterval` as a configurable attribute
* Add unit test for `client` config in `main_test.go`
* Add missing config examples in default `config.yaml`
* Fix up examples to match standard casing in config.go
* Update README.md where appropriate

Refactoring all "sdk client" config into a single namespace for clarity and tighten up docs and examples along the way.