### PR TITLE
fix: Add documentation for auth & TLS functionality, plus related fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,30 +64,33 @@ Below is a comprehensive list of available configuration properties.
 
 |Property Name|Env Variable|Description|
 |---|---|---|
-|config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
+|admin.auth.clients|N/A|Credentials for requesting access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.auth.jwksURL|OPTIMIZELY_ADMIN_AUTH_JWKSURL|JWKS URL for validating access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.auth.hmacSecrets|OPTIMIZELY_ADMIN_AUTH_HMACSECRETS|Signing secret for issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.auth.ttl|OPTIMIZELY_ADMIN_AUTH_TTL|Time-to-live of issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.port|OPTIMIZELY_ADMIN_PORT|Admin listener port. Default: 8088|
+|api.auth.clients|N/A|Credentials for requesting access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.auth.hmacSecrets|OPTIMIZELY_API_AUTH_HMACSECRETS|Signing secret for issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.auth.jwksURL|OPTIMIZELY_API_AUTH_JWKSURL|JWKS URL for validating access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.auth.ttl|OPTIMIZELY_API_AUTH_TTL|Time-to-live of issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
+|api.maxConns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
 |author|OPTIMIZELY_AUTHOR|Agent author. Default: Optimizely Inc.|
+|certfile|OPTIMIZELY_KEYFILE|Path to a certificate file, used to run Agent with HTTPS|
+|client.batchSize|OPTIMIZELY_CLIENT_BATCHSIZE|The number of events in a batch. Default: 10|
+|config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
+|client.flushInterval|OPTIMIZELY_CLIENT_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
+|client.pollingInterval|OPTIMIZELY_CLIENT_POLLINGINTERVAL|The time between successive polls for updated project configuration. Default: 1m|
+|client.queueSize|OPTIMIZELY_CLIENT_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
+|disabledCiphers|OPTIMIZELY_DISABLEDCIPHERS|List of TLS ciphers to disable when accepting HTTPS connections|
+|keyfile|OPTIMIZELY_KEYFILE|Path to a key file, used to run Agent with HTTPS|
+|log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|
+|log.pretty|OPTIMIZELY_LOG_PRETTY|Flag used to set colorized console output as opposed to structured json logs. Default: false|
 |name|OPTIMIZELY_NAME|Agent name. Default: optimizely|
 |version|OPTIMIZELY_VERSION|Agent version. Default: `git describe --tags`|
 |sdkKeys|OPTIMIZELY_SDK_KEYS|List of SDK keys used to initialize on startup|
-|client.pollingInterval|OPTIMIZELY_CLIENT_POLLINGINTERVAL|The time between successive polls for updated project configuration. Default: 1m|
-|client.batchSize|OPTIMIZELY_CLIENT_BATCHSIZE|The number of events in a batch. Default: 10|
-|client.queueSize|OPTIMIZELY_CLIENT_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
-|client.flushInterval|OPTIMIZELY_CLIENT_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|
-|log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|
-|log.pretty|OPTIMIZELY_LOG_PRETTY|Flag used to set colorized console output as opposed to structured json logs. Default: false|
 |server.readTimeout|OPTIMIZELY_SERVER_READTIMEOUT|The maximum duration for reading the entire body. Default: “5s”|
 |server.writeTimeout|OPTIMIZELY_SERVER_WRITETIMEOUT|The maximum duration before timing out writes of the response. Default: “10s”|
-|admin.port|OPTIMIZELY_ADMIN_PORT|Admin listener port. Default: 8088|
-|admin.auth.ttl|OPTIMIZELY_ADMIN_AUTH_TTL|Time-to-live of issued access tokens. See: [Authorization Guide](./docs/auth.md)|
-|admin.auth.hmacSecrets|OPTIMIZELY_ADMIN_AUTH_HMACSECRETS|Signing secret for issued access tokens. See: [Authorization Guide](./docs/auth.md)|
-|admin.auth.jwksURL|OPTIMIZELY_ADMIN_AUTH_JWKSURL|JWKS URL for validating access tokens. See: [Authorization Guide](./docs/auth.md)|
-|admin.auth.clients|N/A|Credentials for requesting access tokens. See: [Authorization Guide](./docs/auth.md)|
-|api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
-|api.maxConns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
-|api.auth.ttl|OPTIMIZELY_API_AUTH_TTL|Time-to-live of issued access tokens. See: [Authorization Guide](./docs/auth.md)|
-|api.auth.hmacSecrets|OPTIMIZELY_API_AUTH_HMACSECRETS|Signing secret for issued access tokens. See: [Authorization Guide](./docs/auth.md)|
-|api.auth.jwksURL|OPTIMIZELY_API_AUTH_JWKSURL|JWKS URL for validating access tokens. See: [Authorization Guide](./docs/auth.md)|
-|api.auth.clients|N/A|Credentials for requesting access tokens. See: [Authorization Guide](./docs/auth.md)|
 |webhook.port|OPTIMIZELY_WEBHOOK_PORT|Webhook listener port: Default: 8085|
 |webhook.projects.<*projectId*>.sdkKeys|N/A|Comma delimited list of SDK Keys applicable to the respective projectId|
 |webhook.projects.<*projectId*>.secret|N/A|Webhook secret used to validate webhook requests originating from the respective projectId|

--- a/README.md
+++ b/README.md
@@ -78,8 +78,16 @@ Below is a comprehensive list of available configuration properties.
 |server.readTimeout|OPTIMIZELY_SERVER_READTIMEOUT|The maximum duration for reading the entire body. Default: “5s”|
 |server.writeTimeout|OPTIMIZELY_SERVER_WRITETIMEOUT|The maximum duration before timing out writes of the response. Default: “10s”|
 |admin.port|OPTIMIZELY_ADMIN_PORT|Admin listener port. Default: 8088|
+|admin.auth.ttl|OPTIMIZELY_ADMIN_AUTH_TTL|Time-to-live of issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.auth.hmacSecrets|OPTIMIZELY_ADMIN_AUTH_HMACSECRETS|Signing secret for issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.auth.jwksURL|OPTIMIZELY_ADMIN_AUTH_JWKSURL|JWKS URL for validating access tokens. See: [Authorization Guide](./docs/auth.md)|
+|admin.auth.clients|N/A|Credentials for requesting access tokens. See: [Authorization Guide](./docs/auth.md)|
 |api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
 |api.maxConns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
+|api.auth.ttl|OPTIMIZELY_API_AUTH_TTL|Time-to-live of issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.auth.hmacSecrets|OPTIMIZELY_API_AUTH_HMACSECRETS|Signing secret for issued access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.auth.jwksURL|OPTIMIZELY_API_AUTH_JWKSURL|JWKS URL for validating access tokens. See: [Authorization Guide](./docs/auth.md)|
+|api.auth.clients|N/A|Credentials for requesting access tokens. See: [Authorization Guide](./docs/auth.md)|
 |webhook.port|OPTIMIZELY_WEBHOOK_PORT|Webhook listener port: Default: 8085|
 |webhook.projects.<*projectId*>.sdkKeys|N/A|Comma delimited list of SDK Keys applicable to the respective projectId|
 |webhook.projects.<*projectId*>.secret|N/A|Webhook secret used to validate webhook requests originating from the respective projectId|
@@ -187,6 +195,9 @@ Custom metrics are also provided for the individual service endpoints and follow
 "timers.<metric-name>.responseTimeHist.p95": 0,
 "timers.<metric-name>.responseTimeHist.p99": 0,
 ```
+
+## Authorization
+Optimizely Agent supports authorization workflows based on OAuth and JWT standards, allowing you to protect access to its API and Admin interfaces. For details, see the [Authorization Guide](./docs/auth.md).
 
 ## Package Structure
 Following best practice for go project layout as defined [here](https://github.com/golang-standards/project-layout)

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Below is a comprehensive list of available configuration properties.
 |api.port|OPTIMIZELY_API_PORT|Api listener port. Default: 8080|
 |api.maxConns|OPTIMIZLEY_API_MAXCONNS|Maximum number of concurrent requests|
 |author|OPTIMIZELY_AUTHOR|Agent author. Default: Optimizely Inc.|
-|certfile|OPTIMIZELY_KEYFILE|Path to a certificate file, used to run Agent with HTTPS|
+|certfile|OPTIMIZELY_CERTFILE|Path to a certificate file, used to run Agent with HTTPS|
 |client.batchSize|OPTIMIZELY_CLIENT_BATCHSIZE|The number of events in a batch. Default: 10|
 |config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
 |client.flushInterval|OPTIMIZELY_CLIENT_FLUSHINTERVAL|The maximum time between events being dispatched. Default: 30s|

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -60,8 +60,9 @@ func assertAdmin(t *testing.T, actual config.AdminConfig) {
 
 func assertAdminAuth(t *testing.T, actual config.ServiceAuthConfig) {
 	assert.Equal(t, 30*time.Minute, actual.TTL)
-	assert.Len(t, actual.HMACSecrets, 1)
+	assert.Len(t, actual.HMACSecrets, 2)
 	assert.Equal(t, "efgh", actual.HMACSecrets[0])
+	assert.Equal(t, "ijkl", actual.HMACSecrets[1])
 	assert.Equal(t, config.OAuthClientCredentials{
 		ID:     "clientid2",
 		Secret: "clientsecret2",
@@ -77,8 +78,9 @@ func assertAPI(t *testing.T, actual config.APIConfig) {
 
 func assertAPIAuth(t *testing.T, actual config.ServiceAuthConfig) {
 	assert.Equal(t, 30*time.Minute, actual.TTL)
-	assert.Len(t, actual.HMACSecrets, 1)
+	assert.Len(t, actual.HMACSecrets, 2)
 	assert.Equal(t, "abcd", actual.HMACSecrets[0])
+	assert.Equal(t, "efgh", actual.HMACSecrets[1])
 	assert.Equal(t, config.OAuthClientCredentials{
 		ID:     "clientid1",
 		Secret: "clientsecret1",
@@ -139,7 +141,7 @@ func TestViperProps(t *testing.T) {
 
 	v.Set("admin.port", "3002")
 	v.Set("admin.auth.ttl", "30m")
-	v.Set("admin.auth.hmacSecrets", "efgh")
+	v.Set("admin.auth.hmacSecrets", "efgh,ijkl")
 	v.Set("admin.auth.clients", []map[string]string{
 		{
 			"id":     "clientid2",
@@ -152,7 +154,7 @@ func TestViperProps(t *testing.T) {
 	v.Set("api.enableOverrides", true)
 	v.Set("api.port", "3000")
 	v.Set("api.auth.ttl", "30m")
-	v.Set("api.auth.hmacSecrets", "abcd")
+	v.Set("api.auth.hmacSecrets", "abcd,efgh")
 	v.Set("api.auth.clients", []map[string]string{
 		{
 			"id":     "clientid1",

--- a/cmd/main_test.go
+++ b/cmd/main_test.go
@@ -60,7 +60,8 @@ func assertAdmin(t *testing.T, actual config.AdminConfig) {
 
 func assertAdminAuth(t *testing.T, actual config.ServiceAuthConfig) {
 	assert.Equal(t, 30*time.Minute, actual.TTL)
-	assert.Equal(t, "efgh", actual.HMACSecret)
+	assert.Len(t, actual.HMACSecrets, 1)
+	assert.Equal(t, "efgh", actual.HMACSecrets[0])
 	assert.Equal(t, config.OAuthClientCredentials{
 		ID:     "clientid2",
 		Secret: "clientsecret2",
@@ -76,7 +77,8 @@ func assertAPI(t *testing.T, actual config.APIConfig) {
 
 func assertAPIAuth(t *testing.T, actual config.ServiceAuthConfig) {
 	assert.Equal(t, 30*time.Minute, actual.TTL)
-	assert.Equal(t, "abcd", actual.HMACSecret)
+	assert.Len(t, actual.HMACSecrets, 1)
+	assert.Equal(t, "abcd", actual.HMACSecrets[0])
 	assert.Equal(t, config.OAuthClientCredentials{
 		ID:     "clientid1",
 		Secret: "clientsecret1",
@@ -137,7 +139,7 @@ func TestViperProps(t *testing.T) {
 
 	v.Set("admin.port", "3002")
 	v.Set("admin.auth.ttl", "30m")
-	v.Set("admin.auth.hmacSecret", "efgh")
+	v.Set("admin.auth.hmacSecrets", "efgh")
 	v.Set("admin.auth.clients", []map[string]string{
 		{
 			"id":     "clientid2",
@@ -150,7 +152,7 @@ func TestViperProps(t *testing.T) {
 	v.Set("api.enableOverrides", true)
 	v.Set("api.port", "3000")
 	v.Set("api.auth.ttl", "30m")
-	v.Set("api.auth.hmacSecret", "abcd")
+	v.Set("api.auth.hmacSecrets", "abcd")
 	v.Set("api.auth.clients", []map[string]string{
 		{
 			"id":     "clientid1",

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -25,7 +25,8 @@ admin:
   port: "3002"
   auth:
     ttl: 30m
-    hmacSecret: "efgh"
+    hmacSecrets:
+      - "efgh"
     clients:
       - id: clientid2
         secret: clientsecret2
@@ -36,7 +37,8 @@ api:
   enableOverrides: true
   auth:
     ttl: 30m
-    hmacSecret: "abcd"
+    hmacSecrets:
+      - "abcd"
     clients:
       - id: clientid1
         secret: clientsecret1

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -27,6 +27,7 @@ admin:
     ttl: 30m
     hmacSecrets:
       - "efgh"
+      - "ijkl"
     clients:
       - id: clientid2
         secret: clientsecret2
@@ -39,6 +40,7 @@ api:
     ttl: 30m
     hmacSecrets:
       - "abcd"
+      - "efgh"
     clients:
       - id: clientid1
         secret: clientsecret1

--- a/config/config.go
+++ b/config/config.go
@@ -31,17 +31,17 @@ func NewDefaultConfig() *AgentConfig {
 
 		Admin: AdminConfig{
 			Auth: ServiceAuthConfig{
-				Clients:    make([]OAuthClientCredentials, 0),
-				HMACSecret: "",
-				TTL:        0,
+				Clients:     make([]OAuthClientCredentials, 0),
+				HMACSecrets: make([]string, 0),
+				TTL:         0,
 			},
 			Port: "8088",
 		},
 		API: APIConfig{
 			Auth: ServiceAuthConfig{
-				Clients:    make([]OAuthClientCredentials, 0),
-				HMACSecret: "",
-				TTL:        0,
+				Clients:     make([]OAuthClientCredentials, 0),
+				HMACSecrets: make([]string, 0),
+				TTL:         0,
 			},
 			MaxConns:            0,
 			Port:                "8080",
@@ -148,7 +148,7 @@ type OAuthClientCredentials struct {
 
 // ServiceAuthConfig holds the authentication configuration for a particular service
 type ServiceAuthConfig struct {
-	Clients    []OAuthClientCredentials `yaml:"clients" json:"-"`
-	HMACSecret string                   `yaml:"hmacSecret" json:"-"`
-	TTL        time.Duration            `yaml:"ttl" json:"-"`
+	Clients     []OAuthClientCredentials `yaml:"clients" json:"-"`
+	HMACSecrets []string                 `yaml:"hmacSecrets" json:"-"`
+	TTL         time.Duration            `yaml:"ttl" json:"-"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -41,13 +41,13 @@ func TestDefaultConfig(t *testing.T) {
 
 	assert.Equal(t, "8088", conf.Admin.Port)
 	assert.Equal(t, make([]OAuthClientCredentials, 0), conf.Admin.Auth.Clients)
-	assert.Equal(t, "", conf.Admin.Auth.HMACSecret)
+	assert.Equal(t, make([]string, 0), conf.Admin.Auth.HMACSecrets)
 	assert.Equal(t, time.Duration(0), conf.Admin.Auth.TTL)
 
 	assert.Equal(t, 0, conf.API.MaxConns)
 	assert.Equal(t, "8080", conf.API.Port)
 	assert.Equal(t, make([]OAuthClientCredentials, 0), conf.API.Auth.Clients)
-	assert.Equal(t, "", conf.API.Auth.HMACSecret)
+	assert.Equal(t, make([]string, 0), conf.API.Auth.HMACSecrets)
 	assert.Equal(t, time.Duration(0), conf.API.Auth.TTL)
 	assert.Equal(t, false, conf.API.EnableOverrides)
 	assert.Equal(t, false, conf.API.EnableNotifications)

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -1,0 +1,70 @@
+# Authorization Guide
+
+## Overview
+
+Optimizely Agent supports authorization workflows based on OAuth and JWT standards, allowing you to protect access to its API and Admin interfaces.
+
+There are three modes of operation:
+
+### Issuer & Validator
+Access tokens are issued by Agent itself, using a [Client Credentials grant](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/). Access tokens are signed and validated using the HS256 algorithm with a signing secret provided in configuration.
+
+### Validator-only
+Agent validates access tokens that were issued elsewhere. Access tokens are validated with public keys fetched from a [JWKS](https://tools.ietf.org/html/rfc7517) URL provided in configuration.
+
+### No authorization (default)
+The interface is publicly available.
+
+## Configuration
+- The API and Admin interfaces are each independently configured to run in one of the above-mentioned modes of operation.
+- Authorization configuration is applied under the `auth` key
+- Each mode of operation has its own set of configuration properties, described below.
+
+### Issuer & Validator
+The configuration properties pertaining to Issuer & Validator mode are listed below:
+
+|Property Name|Description|
+|---|---|
+|ttl|Time-to-live of access tokens issued|
+|hmacSecrets|Secret used to sign issued access tokens, using the HMAC SHA256 algorithm|
+|clients|Array of client credentials, any of which can be exchanged for an access token|
+
+### Validator-only
+The configuration properties pertaining to Validator-only mode are listed below:
+
+|Property Name|Description|
+|---|---|
+|jwksURL|URL from which public keys should be fetched for token validation|
+
+### No authorization (default)
+The API & Admin interfaces run with no authorization when no `auth` configuration is given.
+
+### Example configuration file (yaml)
+```yaml
+# In this example, the API interface is configured in Validator-only mode, and the admin
+# interface is configured in Issuer & Validation mode.
+
+api:
+    # Validator-only 
+    auth:
+        # Signing keys will be fetched from this url and used when validating access tokens
+        jwksURL: https://YOUR_DOMAIN/.well-known/jwks.json
+admin:
+    # Issuer & Validator
+    auth:
+        # Access tokens will expire after 30 minutes
+        ttl: 30m
+         # Access tokens will be signed & validated using this secret
+        hmacSecrets:
+            - QPtUGP/RqaXRltZf1QE1KxlF2Iuo09J0buZ3UNKeIr0
+        # Either of these two id/secret pairs can be exchanged for access tokens
+        clients:
+            - id: agentConsumer1
+            secret: XgZTeTvWaZ6fLiey6EBSOxJ2QFdd6dIiUcZGDIIJ+IY 
+            - id: agentConsumer2
+            secret: ssz0EEViKIinkFXxzqncKxz+6VygEc2d2rKf+la5rXM 
+```
+
+## Secret Rotation (Issuer & Validator mode)
+To support secret rotation, both `hmacSecrets` and `clients` are arrays. In `hmacSecrets`, the first array item will be
+used to sign issued tokens, but tokens signed with any of the array items will be considered valid.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -17,7 +17,7 @@ The interface is publicly available.
 
 ## Configuration
 - The API and Admin interfaces are each independently configured to run in one of the above-mentioned modes of operation.
-- Authorization configuration is applied under the `auth` key
+- Authorization configuration is located under the `auth` key
 - Each mode of operation has its own set of configuration properties, described below.
 
 ### Issuer & Validator
@@ -68,3 +68,6 @@ admin:
 ## Secret Rotation (Issuer & Validator mode)
 To support secret rotation, both `hmacSecrets` and `clients` are arrays. In `hmacSecrets`, the first array item will be
 used to sign issued tokens, but tokens signed with any of the array items will be considered valid.
+
+## Example (Python)
+For example requests demonstrating the Issuer & Validator mode, see [here](../examples/auth.py).

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -27,7 +27,7 @@ The configuration properties pertaining to Issuer & Validator mode are listed be
 |---|---|
 |ttl|Time-to-live of access tokens issued|
 |hmacSecrets|Secret used to sign issued access tokens, using the HMAC SHA256 algorithm|
-|clients|Array of client credentials, any of which can be exchanged for an access token|
+|clients|Array of client credentials, any of which can be exchanged for an access token. Each object in the array should have `"id"` and `"secret"` string properties.|
 
 ### Validator-only
 The configuration properties pertaining to Validator-only mode are listed below:

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -9,8 +9,12 @@ There are three modes of operation:
 ### Issuer & Validator
 Access tokens are issued by Agent itself, using a [Client Credentials grant](https://www.oauth.com/oauth2-servers/access-tokens/client-credentials/). Access tokens are signed and validated using the HS256 algorithm with a signing secret provided in configuration.
 
+Issuer & Validator mode is useful if you want to implement authorization, and you are not already running an authorization server that can issue JWTs.
+
 ### Validator-only
 Agent validates access tokens that were issued elsewhere. Access tokens are validated with public keys fetched from a [JWKS](https://tools.ietf.org/html/rfc7517) URL provided in configuration.
+
+Validator-only mode is useful if you want to plug directly into an existing JWT-based workflow already being used in your system or organization.
 
 ### No authorization (default)
 The interface is publicly available.
@@ -39,30 +43,31 @@ The configuration properties pertaining to Validator-only mode are listed below:
 ### No authorization (default)
 The API & Admin interfaces run with no authorization when no `auth` configuration is given.
 
-### Example configuration file (yaml)
+### Example configuration files (yaml)
+#### Issuer & Validator
 ```yaml
-# In this example, the API interface is configured in Validator-only mode, and the admin
-# interface is configured in Issuer & Validation mode.
-
-api:
-    # Validator-only 
-    auth:
-        # Signing keys will be fetched from this url and used when validating access tokens
-        jwksURL: https://YOUR_DOMAIN/.well-known/jwks.json
+### In this example, the Admin interface is configured in Issuer & Validator mode
 admin:
-    # Issuer & Validator
     auth:
         # Access tokens will expire after 30 minutes
         ttl: 30m
-         # Access tokens will be signed & validated using this secret
         hmacSecrets:
+            # Access tokens will be signed & validated using this secret
             - QPtUGP/RqaXRltZf1QE1KxlF2Iuo09J0buZ3UNKeIr0
-        # Either of these two id/secret pairs can be exchanged for access tokens
         clients:
+            # Either of these two id/secret pairs can be exchanged for access tokens
             - id: agentConsumer1
             secret: XgZTeTvWaZ6fLiey6EBSOxJ2QFdd6dIiUcZGDIIJ+IY 
             - id: agentConsumer2
             secret: ssz0EEViKIinkFXxzqncKxz+6VygEc2d2rKf+la5rXM 
+```
+#### Validator-only
+```yaml
+# In this example, the API interface is configured in Validator-only mode
+api:
+    auth:
+        # Signing keys will be fetched from this url and used when validating access tokens
+        jwksURL: https://YOUR_DOMAIN/.well-known/jwks.json
 ```
 
 ## Secret Rotation (Issuer & Validator mode)

--- a/examples/auth.py
+++ b/examples/auth.py
@@ -5,12 +5,13 @@ import json
 import requests
 import sys
 
-# This example demonstrates obtaining an access token and using it to request the
-# current Optimizely Config from the API interface.
-
+# This example demonstrates interacting with Agent running in Issuer & Validator mode.
+# We obtain an access token and use it to request the current Optimizely Config
+# from the API interface.
+#
 # Before running, add the following to your Agent configuration file (default:
 # config.yaml) under the "api" section:
-
+#
 # auth:
 #   ttl: 30m
 #   hmacSecrets:
@@ -18,9 +19,11 @@ import sys
 #   clients:
 #     - id: clientid1
 #       secret: clientsecret1
-
+#
 # With this configuration, an access token can be requested from the
-# /oauth/apitoken endpoint using the configured id and secret. 
+# /oauth/apitoken endpoint using the configured id and secret.
+
+# For more information, see docs/auth.md
 
 if len(sys.argv) < 2:
     sys.exit('Requires one argument: <SDK-Key>')

--- a/examples/auth.py
+++ b/examples/auth.py
@@ -1,0 +1,51 @@
+#!/usr/bin/python
+# example: python auth.py <SDK-Key>
+
+import json
+import requests
+import sys
+
+# This example demonstrates obtaining an access token and using it to request the
+# current Optimizely Config from the API interface.
+
+# Before running, add the following to your Agent configuration file (default:
+# config.yaml) under the "api" section:
+
+# auth:
+#   ttl: 30m
+#   hmacSecrets:
+#     - "abcd"
+#   clients:
+#     - id: clientid1
+#       secret: clientsecret1
+
+# With this configuration, an access token can be requested from the
+# /oauth/apitoken endpoint using the configured id and secret. 
+
+if len(sys.argv) < 2:
+    sys.exit('Requires one argument: <SDK-Key>')
+
+sdk_key = sys.argv[1]
+client_id = sys.argv[2]
+client_secret = sys.argv[3]
+
+s = requests.Session()
+s.headers.update({'X-Optimizely-SDK-Key': sdk_key})
+
+resp = s.get('http://localhost:8080/v1/config')
+print('first config request, not including access token: response status = {}'.format(resp.status_code))
+
+resp = s.post('http://localhost:8080/oauth/api/token', data=json.dumps({
+  'grant_type': 'client_credentials',
+  'client_id':  client_id,
+  'client_secret': client_secret,
+}))
+resp_dict = resp.json()
+print('access token response: ')
+print(json.dumps(resp_dict, indent=4, sort_keys=True))
+
+s.headers.update({'Authorization': 'Bearer {}'.format(resp_dict['access_token'])})
+
+resp = s.get('http://localhost:8080/v1/config')
+print('config response after passing access token: ')
+print(json.dumps(resp.json(), indent=4, sort_keys=True))

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -74,8 +74,13 @@ func NewOAuthHandler(authConfig *config.ServiceAuthConfig) *OAuthHandler {
 		}
 	}
 
+	hmacSecret := ""
+	if len(authConfig.HMACSecrets) > 0 {
+		hmacSecret = authConfig.HMACSecrets[0]
+	}
+
 	h := &OAuthHandler{
-		hmacSecret:        []byte(authConfig.HMACSecret),
+		hmacSecret:        []byte(hmacSecret),
 		ClientCredentials: clientCredentials,
 	}
 	return h
@@ -124,7 +129,6 @@ func (h *OAuthHandler) verifyClientCredentials(r *http.Request) (*ClientCredenti
 		}
 	}
 	clientCreds, ok := h.ClientCredentials[reqBody.ClientID]
-	// TODO: hash client secret and match secret hash
 	if !ok || !jwtauth.ValidateClientSecret(reqBody.ClientSecret, clientCreds.Secret) {
 		return nil, http.StatusUnauthorized, &ClientCredentialsError{
 			ErrorCode:        "invalid_client",

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -100,7 +100,7 @@ func (h *OAuthHandler) verifyClientCredentials(r *http.Request) (*ClientCredenti
 	var reqBody tokenRequest
 	err := ParseRequestBody(r, &reqBody)
 	if err != nil {
-		return nil, 0, err
+		return nil, http.StatusBadRequest, err
 	}
 
 	if reqBody.GrantType == "" {

--- a/pkg/handlers/oauth_test.go
+++ b/pkg/handlers/oauth_test.go
@@ -44,8 +44,8 @@ func (s *OAuthTestSuite) SetupTest() {
 				Secret: "client_seekrit",
 			},
 		},
-		HMACSecret: "hmac_seekrit",
-		TTL:        30 * time.Minute,
+		HMACSecrets: []string{"hmac_seekrit"},
+		TTL:         30 * time.Minute,
 	}
 	s.handler = NewOAuthHandler(&config)
 

--- a/pkg/handlers/oauth_test.go
+++ b/pkg/handlers/oauth_test.go
@@ -212,6 +212,14 @@ func (s *OAuthTestSuite) TestGetAPIAccessTokenMissingSDKKey() {
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
+func (s *OAuthTestSuite) TestGetAPIAccessTokenInvalidBody() {
+	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader([]byte("<><**")))
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	s.Equal(http.StatusBadRequest, rec.Code)
+}
+
+
 func (s *OAuthTestSuite) TestGetAPIAccessTokenSuccess() {
 	bodyBytes, _ := json.Marshal(map[string]string{
 		"grant_type":    "client_credentials",

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -74,9 +74,8 @@ func (c JWTVerifier) CheckToken(token string) (*jwt.Token, error) {
 	}
 
 	err := errors.New("invalid token")
-	var tk  *jwt.Token
 	for _, secretKey := range c.secretKeys {
-		tk, err = jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
+		tk, err := jwt.Parse(token, func(token *jwt.Token) (interface{}, error) {
 			if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
 				return nil, errors.New("unexpected signing method")
 			}

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -64,9 +64,9 @@ func (suite *AuthTestSuite) SetupTest() {
 
 	suite.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	suite.authConfig = &config.ServiceAuthConfig{
-		Clients:    make([]config.OAuthClientCredentials, 0),
-		HMACSecret: suite.signature,
-		TTL:        0,
+		Clients:     make([]config.OAuthClientCredentials, 0),
+		HMACSecrets: []string{suite.signature},
+		TTL:         0,
 	}
 
 }

--- a/pkg/middleware/auth_test.go
+++ b/pkg/middleware/auth_test.go
@@ -40,32 +40,38 @@ func (c OptlyClaims) Valid() error {
 
 type AuthTestSuite struct {
 	suite.Suite
-	validAPIToken   *jwt.Token
-	validAdminToken *jwt.Token
-	expiredToken    *jwt.Token
-	handler         http.HandlerFunc
-	signature       string
-	authConfig      *config.ServiceAuthConfig
+	validAPIToken         *jwt.Token
+	validAPITokenOtherSig *jwt.Token
+	validAdminToken       *jwt.Token
+	expiredToken          *jwt.Token
+	handler               http.HandlerFunc
+	signatures            []string
+	authConfig            *config.ServiceAuthConfig
 }
 
 func (suite *AuthTestSuite) SetupTest() {
-	suite.signature = "test"
+	suite.signatures = []string{"test", "test2"}
+
 	claims := OptlyClaims{ExpiresAt: 12313123123213, SdkKey: "SDK_KEY", Issuer: "iss"} // exp = March 9, 2360
 	suite.validAPIToken = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	suite.validAPIToken.Raw, _ = suite.validAPIToken.SignedString([]byte(suite.signature))
+	suite.validAPIToken.Raw, _ = suite.validAPIToken.SignedString([]byte(suite.signatures[0]))
+
+	claims = OptlyClaims{ExpiresAt: 12313123123213, SdkKey: "SDK_KEY", Issuer: "iss"} // exp = March 9, 2360
+	suite.validAPITokenOtherSig = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+	suite.validAPITokenOtherSig.Raw, _ = suite.validAPITokenOtherSig.SignedString([]byte(suite.signatures[1]))
 
 	claims = OptlyClaims{ExpiresAt: 12313123123213, Admin: true, Issuer: "iss"} // exp = March 9, 2360
 	suite.validAdminToken = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	suite.validAdminToken.Raw, _ = suite.validAdminToken.SignedString([]byte(suite.signature))
+	suite.validAdminToken.Raw, _ = suite.validAdminToken.SignedString([]byte(suite.signatures[0]))
 
 	claims = OptlyClaims{ExpiresAt: 0, SdkKey: "SDK_KEY", Issuer: "iss"}
 	suite.expiredToken = jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	suite.expiredToken.Raw, _ = suite.expiredToken.SignedString([]byte(suite.signature))
+	suite.expiredToken.Raw, _ = suite.expiredToken.SignedString([]byte(suite.signatures[0]))
 
 	suite.handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {})
 	suite.authConfig = &config.ServiceAuthConfig{
 		Clients:     make([]config.OAuthClientCredentials, 0),
-		HMACSecrets: []string{suite.signature},
+		HMACSecrets: suite.signatures,
 		TTL:         0,
 	}
 
@@ -143,6 +149,18 @@ func (suite *AuthTestSuite) TestAuthAuthorizeAPITokenAuthorizationValidClaims() 
 	rec := httptest.NewRecorder()
 	req := httptest.NewRequest("GET", "/some_url", nil)
 	req.Header.Add("Authorization", "Bearer "+suite.validAPIToken.Raw)
+	req.Header.Add(OptlySDKHeader, "SDK_KEY")
+
+	auth.AuthorizeAPI(suite.handler).ServeHTTP(rec, req)
+	suite.Equal(http.StatusOK, rec.Code)
+}
+
+func (suite *AuthTestSuite) TestAuthAuthorizeAPITokenAuthorizationValidClaimsOtherSig() {
+
+	auth := NewAuth(suite.authConfig)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/some_url", nil)
+	req.Header.Add("Authorization", "Bearer "+suite.validAPITokenOtherSig.Raw)
 	req.Header.Add(OptlySDKHeader, "SDK_KEY")
 
 	auth.AuthorizeAPI(suite.handler).ServeHTTP(rec, req)


### PR DESCRIPTION
## Summary

This provides documentation regarding authorization and TLS functionality recently added. This includes updates to the config properties table, an authorization guide under `/docs` , and a python example under `/examples`.

Also included are fixes for small issues uncovered while creating the documentation:
- Added support for multiple HMAC validation secrets, to facilitate zero-downtime rotation. The first secret in the array will be used to sign issued tokens
- Fix for an invalid response code (`0`) when the token issuer endpoint received invalid JSON in the request body

## JIRA
https://optimizely.atlassian.net/browse/OASIS-5899