### PR TITLE
fix: Don't start with invalid auth configuration (missing hmac secret)

### DIFF
--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -164,6 +164,7 @@ func renderClientCredentialsError(err error, status int, w http.ResponseWriter, 
 
 // CreateAPIAccessToken returns a JWT access token for the API service
 func (h *OAuthHandler) CreateAPIAccessToken(w http.ResponseWriter, r *http.Request) {
+
 	clientCreds, httpCode, err := h.verifyClientCredentials(r)
 	if err != nil {
 		renderClientCredentialsError(err, httpCode, w, r)

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -164,10 +164,16 @@ func renderClientCredentialsError(err error, status int, w http.ResponseWriter, 
 
 // CreateAPIAccessToken returns a JWT access token for the API service
 func (h *OAuthHandler) CreateAPIAccessToken(w http.ResponseWriter, r *http.Request) {
-
 	clientCreds, httpCode, err := h.verifyClientCredentials(r)
 	if err != nil {
 		renderClientCredentialsError(err, httpCode, w, r)
+		return
+	}
+
+	if len(h.hmacSecret) == 0 {
+		middleware.GetLogger(r).Error().Msg("Invalid hmac secret in configuration, can't issue token")
+		render.Status(r, http.StatusInternalServerError)
+		render.PlainText(w, r, "Invalid server configuration, can't issue token")
 		return
 	}
 
@@ -196,6 +202,13 @@ func (h *OAuthHandler) CreateAdminAccessToken(w http.ResponseWriter, r *http.Req
 	clientCreds, httpCode, err := h.verifyClientCredentials(r)
 	if err != nil {
 		renderClientCredentialsError(err, httpCode, w, r)
+		return
+	}
+
+	if len(h.hmacSecret) == 0 {
+		middleware.GetLogger(r).Error().Msg("Invalid hmac secret in configuration, can't issue token")
+		render.Status(r, http.StatusInternalServerError)
+		render.PlainText(w, r, "Invalid server configuration, can't issue token")
 		return
 	}
 

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -18,6 +18,7 @@
 package handlers
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -172,9 +173,7 @@ func (h *OAuthHandler) CreateAPIAccessToken(w http.ResponseWriter, r *http.Reque
 	}
 
 	if len(h.hmacSecret) == 0 {
-		middleware.GetLogger(r).Error().Msg("Invalid hmac secret in configuration, can't issue token")
-		render.Status(r, http.StatusInternalServerError)
-		render.PlainText(w, r, "Invalid server configuration, can't issue token")
+		RenderError(errors.New("Invalid server configuration, can't issue token"), http.StatusInternalServerError, w, r)
 		return
 	}
 
@@ -207,9 +206,7 @@ func (h *OAuthHandler) CreateAdminAccessToken(w http.ResponseWriter, r *http.Req
 	}
 
 	if len(h.hmacSecret) == 0 {
-		middleware.GetLogger(r).Error().Msg("Invalid hmac secret in configuration, can't issue token")
-		render.Status(r, http.StatusInternalServerError)
-		render.PlainText(w, r, "Invalid server configuration, can't issue token")
+		RenderError(errors.New("Invalid server configuration, can't issue token"), http.StatusInternalServerError, w, r)
 		return
 	}
 

--- a/pkg/handlers/oauth_test.go
+++ b/pkg/handlers/oauth_test.go
@@ -221,7 +221,6 @@ func (s *OAuthTestSuite) TestGetAPIAccessTokenInvalidBody() {
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
-
 func (s *OAuthTestSuite) TestGetAPIAccessTokenSuccess() {
 	bodyBytes, _ := json.Marshal(map[string]string{
 		"grant_type":    "client_credentials",
@@ -311,4 +310,60 @@ func (s *OAuthDisabledTestSuite) TestGetAPIAccessTokenDisabled() {
 
 func TestOAuthDisabledTestSuite(t *testing.T) {
 	suite.Run(t, new(OAuthDisabledTestSuite))
+}
+
+type OAuthMissingHMACSecretTestSuite struct {
+	suite.Suite
+	handler *OAuthHandler
+	mux     *chi.Mux
+	secret  string
+}
+
+func (s *OAuthMissingHMACSecretTestSuite) SetupTest() {
+	s.secret = "RW+Uo/7z4ag9hAb10w8LIZFRFaSwS4nt1/l+uVgChIQ="
+	config := config.ServiceAuthConfig{
+		Clients: []config.OAuthClientCredentials{
+			{
+				ID:         "optly_user",
+				SecretHash: "JDJhJDEyJDNDOG12LmNCNzlHaHhGcEJtLzZZQk9VLnRneEpGTTlnTXozb2kyNS9ERzhJTDZOZkpGa0ND",
+			},
+		},
+		// No HMACSecrets provided, so should not issue token, and should return 500 status
+		HMACSecrets: []string{},
+		TTL:         30 * time.Minute,
+	}
+	s.handler = NewOAuthHandler(&config)
+
+	mux := chi.NewMux()
+	mux.Post("/api/token", s.handler.CreateAPIAccessToken)
+	mux.Post("/admin/token", s.handler.CreateAdminAccessToken)
+	s.mux = mux
+}
+
+func (s *OAuthMissingHMACSecretTestSuite) TestGetAdminAccessTokenDisabled() {
+	bodyBytes, _ := json.Marshal(map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     "optly_user",
+		"client_secret": s.secret,
+	})
+	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	s.Equal(http.StatusInternalServerError, rec.Code)
+}
+
+func (s *OAuthMissingHMACSecretTestSuite) TestGetAPIAccessTokenDisabled() {
+	bodyBytes, _ := json.Marshal(map[string]string{
+		"grant_type":    "client_credentials",
+		"client_id":     "optly_user",
+		"client_secret": s.secret,
+	})
+	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+	s.Equal(http.StatusInternalServerError, rec.Code)
+}
+
+func TestOAuthMissingHMACSecretTestSuite(t *testing.T) {
+	suite.Run(t, new(OAuthMissingHMACSecretTestSuite))
 }

--- a/pkg/handlers/oauth_test.go
+++ b/pkg/handlers/oauth_test.go
@@ -221,6 +221,7 @@ func (s *OAuthTestSuite) TestGetAPIAccessTokenInvalidBody() {
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
+
 func (s *OAuthTestSuite) TestGetAPIAccessTokenSuccess() {
 	bodyBytes, _ := json.Marshal(map[string]string{
 		"grant_type":    "client_credentials",
@@ -328,7 +329,7 @@ func (s *OAuthMissingHMACSecretTestSuite) SetupTest() {
 				SecretHash: "JDJhJDEyJDNDOG12LmNCNzlHaHhGcEJtLzZZQk9VLnRneEpGTTlnTXozb2kyNS9ERzhJTDZOZkpGa0ND",
 			},
 		},
-		// No HMACSecrets provided, so should not issue token, and should return 500 status
+		// No HMACSecrets provided - this configuration is invalid
 		HMACSecrets: []string{},
 		TTL:         30 * time.Minute,
 	}
@@ -340,28 +341,8 @@ func (s *OAuthMissingHMACSecretTestSuite) SetupTest() {
 	s.mux = mux
 }
 
-func (s *OAuthMissingHMACSecretTestSuite) TestGetAdminAccessTokenDisabled() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
-	rec := httptest.NewRecorder()
-	s.mux.ServeHTTP(rec, req)
-	s.Equal(http.StatusInternalServerError, rec.Code)
-}
-
-func (s *OAuthMissingHMACSecretTestSuite) TestGetAPIAccessTokenDisabled() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	rec := httptest.NewRecorder()
-	s.mux.ServeHTTP(rec, req)
-	s.Equal(http.StatusInternalServerError, rec.Code)
+func (s *OAuthMissingHMACSecretTestSuite) TestInvalidConfig() {
+	s.Nil(s.handler)
 }
 
 func TestOAuthMissingHMACSecretTestSuite(t *testing.T) {

--- a/pkg/routers/admin.go
+++ b/pkg/routers/admin.go
@@ -40,8 +40,13 @@ func NewAdminRouter(conf config.AgentConfig) http.Handler {
 		return nil
 	}
 
-	optlyAdmin := handlers.NewAdmin(conf)
 	tokenHandler := handlers.NewOAuthHandler(&conf.Admin.Auth)
+	if tokenHandler == nil {
+		log.Error().Msg("unable to initialize admin auth handler.")
+		return nil
+	}
+
+	optlyAdmin := handlers.NewAdmin(conf)
 	r.Use(optlyAdmin.AppInfoHeader)
 
 	r.Use(render.SetContentType(render.ContentTypeJSON))

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -56,6 +56,12 @@ func NewDefaultAPIRouter(optlyCache optimizely.Cache, conf config.APIConfig, met
 		return nil
 	}
 
+	authHandler := handlers.NewOAuthHandler(&conf.Auth)
+	if authHandler == nil {
+		log.Error().Msg("unable to initialize api auth handler.")
+		return nil
+	}
+
 	var notificationsAPI handlers.NotificationAPI
 	notificationsAPI = handlers.NewDisabledNotificationHandler()
 	if conf.EnableNotifications {
@@ -77,7 +83,7 @@ func NewDefaultAPIRouter(optlyCache optimizely.Cache, conf config.APIConfig, met
 		notificationsAPI: notificationsAPI,
 		userOverrideAPI:  userOverrideAPI,
 		metricsRegistry:  metricsRegistry,
-		oAuthHandler:     handlers.NewOAuthHandler(&conf.Auth),
+		oAuthHandler:     authHandler,
 		oAuthMiddleware:  authProvider,
 		enableOverrides:  conf.EnableOverrides,
 	}

--- a/pkg/routers/api_v1.go
+++ b/pkg/routers/api_v1.go
@@ -83,6 +83,8 @@ func NewDefaultAPIV1Router(optlyCache optimizely.Cache, conf config.APIConfig, m
 		middleware:      &middleware.CachedOptlyMiddleware{Cache: optlyCache},
 		handlers:        new(defaultHandlers),
 		metricsRegistry: metricsRegistry,
+		// TODO: These two below (NewOAuthHandler and NewAuth) can return nil when given invalid configuration
+		// Make sure to handle that possibility here
 		oAuthHandler:    handlers.NewOAuthHandler(&conf.Auth),
 		oAuthMiddleware: middleware.NewAuth(&conf.Auth),
 	}

--- a/pkg/routers/api_v1_test.go
+++ b/pkg/routers/api_v1_test.go
@@ -169,3 +169,27 @@ func TestNewDefaultClientRouter(t *testing.T) {
 	client := NewDefaultAPIRouter(MockCache{}, config.APIConfig{}, metricsRegistry)
 	assert.NotNil(t, client)
 }
+
+func TestNewDefaultClientRouterInvalidConfig(t *testing.T) {
+	invalidAPIConfig := config.APIConfig{
+		Auth:                config.ServiceAuthConfig{
+			Clients: []config.OAuthClientCredentials{
+				{
+					ID:         "id1",
+					SecretHash: "JDJhJDEyJFBQM3dSdnNERnVSQmZPNnA4MGcvLk9Eb1RVWExYMm5FZ2VhZXpsS1VmR3hPdFJUT3ViaXVX",
+				},
+			},
+			// Empty HMACSecrets, but non-empty Clients, is an invalid config
+			HMACSecrets: []string{},
+			TTL:                0,
+			JwksURL:            "",
+			JwksUpdateInterval: 0,
+		},
+		MaxConns:            100,
+		Port:                "8080",
+		EnableNotifications: false,
+		EnableOverrides:     false,
+	}
+	client := NewDefaultAPIRouter(MockCache{}, invalidAPIConfig, metricsRegistry)
+	assert.Nil(t, client)
+}


### PR DESCRIPTION
## Summary
Fix the following bug in the access token issuer endpoint: 
- Valid client credentials are set in configuration
- Agent config lacks an hmac secret or was configured with an empty hmac secret

Expected:
- Server does not start with invalid configuration

Actual:
- Server starts and issues access tokens with invalid config

With this change, the server does not start, and errors are logged
