### PR TITLE
/activate endpoint leniency

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -261,11 +261,7 @@ components:
           type: object
           additionalProperties:
             type: string
-        invalid:
-          type: boolean
-        key:
-          type: string
-        message:
+        error:
           type: string
       required:
         #        - id

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -261,6 +261,12 @@ components:
           type: object
           additionalProperties:
             type: string
+        invalid:
+          type: boolean
+        key:
+          type: string
+        message:
+          type: string
       required:
         #        - id
         - key

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -108,7 +108,7 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 	render.JSON(w, r, decisions)
 }
 
-func parseExperimentKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap) error {
+func parseExperimentKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap) {
 	for _, key := range keys {
 		_, ok := oConf.ExperimentsMap[key]
 		if !ok {
@@ -117,11 +117,9 @@ func parseExperimentKeys(keys []string, oConf *config.OptimizelyConfig, kmap key
 			kmap[key] = "experiment"
 		}
 	}
-
-	return nil
 }
 
-func parseFeatureKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap) error {
+func parseFeatureKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap) {
 	for _, key := range keys {
 		_, ok := oConf.FeaturesMap[key]
 		if !ok {
@@ -130,8 +128,6 @@ func parseFeatureKeys(keys []string, oConf *config.OptimizelyConfig, kmap keyMap
 			kmap[key] = "feature"
 		}
 	}
-
-	return nil
 }
 
 func parseTypeParameter(types []string, oConf *config.OptimizelyConfig, kmap keyMap) error {

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -81,16 +81,14 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 			d, err = optlyClient.ActivateFeature(key, uc, disableTracking)
 		case "experimentKey-not-found":
 			d = &optimizely.Decision{
-				Invalid: true,
-				Key: key,
-				Message: "experimentKey not found",
+				ExperimentKey: key,
+				Error: "experimentKey not found",
 			}
 			err = nil
 		case "featureKey-not-found":
 			d = &optimizely.Decision{
-				Invalid: true,
-				Key: key,
-				Message: "featureKey not found",
+				FeatureKey: key,
+				Error: "featureKey not found",
 			}
 			err = nil
 		default:

--- a/pkg/handlers/activate_test.go
+++ b/pkg/handlers/activate_test.go
@@ -168,9 +168,8 @@ func (suite *ActivateTestSuite) TestGetFeatureMissingFeature() {
 	suite.NoError(err)
 
 	expected := optimizely.Decision{
-		Invalid:    true,
-		Key:        "feature-missing",
-		Message:    "featureKey not found",
+		FeatureKey: "feature-missing",
+		Error:      "featureKey not found",
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -215,9 +214,8 @@ func (suite *ActivateTestSuite) TestGetVariationMissingExperiment() {
 	suite.NoError(err)
 
 	expected := optimizely.Decision{
-		Invalid:    true,
-		Key:        "experiment-missing",
-		Message:    "experimentKey not found",
+		ExperimentKey: "experiment-missing",
+		Error:         "experimentKey not found",
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))

--- a/pkg/handlers/activate_test.go
+++ b/pkg/handlers/activate_test.go
@@ -160,7 +160,21 @@ func (suite *ActivateTestSuite) TestGetFeatureMissingFeature() {
 	req := httptest.NewRequest("POST", "/activate?featureKey=feature-missing", suite.body)
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusNotFound, rec.Code)
+	suite.Equal(http.StatusOK, rec.Code)
+
+	// Unmarshal response
+	var actual []optimizely.Decision
+	err := json.Unmarshal(rec.Body.Bytes(), &actual)
+	suite.NoError(err)
+
+	expected := optimizely.Decision{
+		Invalid:    true,
+		Key:        "feature-missing",
+		Message:    "featureKey not found",
+	}
+
+	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
+	suite.Equal(expected, actual[0])
 }
 
 func (suite *ActivateTestSuite) TestGetVariation() {
@@ -193,15 +207,21 @@ func (suite *ActivateTestSuite) TestGetVariationMissingExperiment() {
 	req := httptest.NewRequest("POST", "/activate?experimentKey=experiment-missing", suite.body)
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusNotFound, rec.Code)
+	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	actual := ErrorResponse{}
+	var actual []optimizely.Decision
 	err := json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
+	expected := optimizely.Decision{
+		Invalid:    true,
+		Key:        "experiment-missing",
+		Message:    "experimentKey not found",
+	}
+
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
-	suite.Equal(ErrorResponse{Error: "experimentKey not-found"}, actual)
+	suite.Equal(expected, actual[0])
 }
 
 func (suite *ActivateTestSuite) TestActivateExperiment() {

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -47,9 +47,7 @@ type Decision struct {
 	Type          string                 `json:"type"`
 	Variables     map[string]interface{} `json:"variables,omitempty"`
 	Enabled       bool                   `json:"enabled"`
-	Invalid       bool                   `json:"invalid"`
-	Key           string                 `json:"key"`
-	Message       string                 `json:"message"`
+	Error         string                 `json:"error"`
 }
 
 // ListFeatures returns all available features

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -47,6 +47,9 @@ type Decision struct {
 	Type          string                 `json:"type"`
 	Variables     map[string]interface{} `json:"variables,omitempty"`
 	Enabled       bool                   `json:"enabled"`
+	Invalid       bool                   `json:"invalid"`
+	Key           string                 `json:"key"`
+	Message       string                 `json:"message"`
 }
 
 // ListFeatures returns all available features

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -50,6 +50,12 @@ func TestStartAndShutdown(t *testing.T) {
 	srv.Shutdown()
 }
 
+func TestNoHandler(t *testing.T) {
+	ns, err := NewServer("test", "0", nil, conf)
+	assert.Error(t, err)
+	assert.Equal(t, ns, Server{})
+}
+
 func TestNotEnabledServer(t *testing.T) {
 	_, err := NewServer("not-enabled", "0", handler, conf)
 	assert.NoError(t, err) // this is checked in server group


### PR DESCRIPTION
## Summary
This PR changes how the /activate endpoint handles experiment and feature keys that can't be found in the datafile. Instead of returning a 'key not found' message, it will return info detailing what specific key wasn't able to be found, while also returning info about the experiments that _were_ found.

**They "why"**
The /activate endpoint currently allows multiple experiment and feature keys to be passed up as params. However, if _any_ of those keys cannot be found in the current datafile an error is returned, even if some of the keys were able to be found.

It is very common that a code base includes code for some experiments that are turned on, and some that aren't, but if an app that uses this service wants to batch its calls together for performance and efficiency, then this makes it impossible to do so.

**An example**
A client-side app loads a page with any number of experiments running on it. It has a list of these existing experiments and uses that to make a request to /activate with the keys for all the features and experiments and awaits a response so that it can show the correct experience to the user. One of the experiments has not been turned on yet, or perhaps has just been turned off because it was complete or caused an unexpected error. Because of that the call to /activate will return an error and none of the experiments will work. The only alternative in this case is to make a separate call for each individual experiment, which takes longer and is less performant
