### PR TITLE
fix: In API access token issuer, use SDK keys from configuration, not request header

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -103,7 +103,7 @@ paths:
     post:
       summary: Get JWT token to authenticate all requests.
       operationId: getToken
-      description: Generate JWT token for grant_type, client_id and client_secret. It matches the configured values and generates a valid token with expiration provided in configuration.
+      description: Generate JWT token for grant_type, client_id and client_secret. It matches the configured values and generates a valid token. Expiration time, and SDK keys to which the token grants access, are provided in configuration.
       responses:
         '200':
           description: Generates a valid token

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -103,7 +103,7 @@ paths:
     post:
       summary: Get JWT token to authenticate all requests.
       operationId: getToken
-      description: Generate JWT token for grant_type, client_id and client_secret, and X-Optimizely-SDK-Key as well. It matches the configured values and generates a valid token with expiration provided in configuration.
+      description: Generate JWT token for grant_type, client_id and client_secret. It matches the configured values and generates a valid token with expiration provided in configuration.
       responses:
         '200':
           description: Generates a valid token

--- a/cmd/optimizely/main_test.go
+++ b/cmd/optimizely/main_test.go
@@ -66,6 +66,7 @@ func assertAdminAuth(t *testing.T, actual config.ServiceAuthConfig) {
 	assert.Equal(t, config.OAuthClientCredentials{
 		ID:         "clientid2",
 		SecretHash: "clientsecret2",
+		SDKKeys:    []string{"123"},
 	}, actual.Clients[0])
 	assert.Equal(t, "admin_jwks_url", actual.JwksURL)
 	assert.Equal(t, 25*time.Second, actual.JwksUpdateInterval)
@@ -86,6 +87,7 @@ func assertAPIAuth(t *testing.T, actual config.ServiceAuthConfig) {
 	assert.Equal(t, config.OAuthClientCredentials{
 		ID:         "clientid1",
 		SecretHash: "clientsecret1",
+		SDKKeys:    []string{"123"},
 	}, actual.Clients[0])
 	assert.Equal(t, "api_jwks_url", actual.JwksURL)
 	assert.Equal(t, 25*time.Second, actual.JwksUpdateInterval)
@@ -149,10 +151,11 @@ func TestViperProps(t *testing.T) {
 	v.Set("admin.auth.jwksURL", "admin_jwks_url")
 	v.Set("admin.auth.jwksUpdateInterval", "25s")
 
-	v.Set("admin.auth.clients", []map[string]string{
+	v.Set("admin.auth.clients", []map[string]interface{}{
 		{
-			"id":     "clientid2",
+			"id":         "clientid2",
 			"secretHash": "clientsecret2",
+			"sdkKeys":    []string{"123"},
 		},
 	})
 
@@ -166,10 +169,11 @@ func TestViperProps(t *testing.T) {
 	v.Set("api.auth.jwksURL", "api_jwks_url")
 	v.Set("api.auth.jwksUpdateInterval", "25s")
 
-	v.Set("api.auth.clients", []map[string]string{
+	v.Set("api.auth.clients", []map[string]interface{}{
 		{
-			"id":     "clientid1",
+			"id":         "clientid1",
 			"secretHash": "clientsecret1",
+			"sdkKeys":    []string{"123"},
 		},
 	})
 

--- a/cmd/testdata/default.yaml
+++ b/cmd/testdata/default.yaml
@@ -31,6 +31,8 @@ admin:
     clients:
       - id: clientid2
         secretHash: clientsecret2
+        sdkKeys:
+          - 123
     jwksURL: "admin_jwks_url"
     jwksUpdateInterval: "25s"
 api:
@@ -46,6 +48,8 @@ api:
     clients:
       - id: clientid1
         secretHash: clientsecret1
+        sdkKeys:
+          - 123
     jwksURL: "api_jwks_url"
     jwksUpdateInterval: "25s"
 webhook:

--- a/config.yaml
+++ b/config.yaml
@@ -18,7 +18,7 @@ name: "optimizely"
 ##
 log:
     ## log level used to filter logs of lesser severity (from highest to lowest):
-    ## panic, fatal, error, warn, info, debug, trace
+    ## panic, fatal, error, warn, info, debug
     level: info
     ## enable pretty colorized console logging. setting to false will output
     ## structured JSON logs. Recommended false in production.

--- a/config/config.go
+++ b/config/config.go
@@ -148,7 +148,7 @@ type WebhookProject struct {
 type OAuthClientCredentials struct {
 	ID         string   `yaml:"id"`
 	SecretHash string   `yaml:"secretHash"`
-	SDKKeys    []string `yaml:sdkKeys`
+	SDKKeys    []string `yaml:"sdkKeys"`
 }
 
 // ServiceAuthConfig holds the authentication configuration for a particular service

--- a/config/config.go
+++ b/config/config.go
@@ -146,8 +146,9 @@ type WebhookProject struct {
 
 // OAuthClientCredentials are used for issuing access tokens
 type OAuthClientCredentials struct {
-	ID         string `yaml:"id"`
-	SecretHash string `yaml:"secretHash"`
+	ID         string   `yaml:"id"`
+	SecretHash string   `yaml:"secretHash"`
+	SDKKeys    []string `yaml:sdkKeys`
 }
 
 // ServiceAuthConfig holds the authentication configuration for a particular service

--- a/examples/auth.py
+++ b/examples/auth.py
@@ -7,29 +7,40 @@ import sys
 # This example demonstrates interacting with Agent running in Issuer & Validator mode.
 # We obtain an access token and use it to request the current Optimizely Config
 # from the API interface.
-#
-# First, we need client credentials (ID & secret), and the BCrypt hash of our secret
-# You can use the generate_secret tool included with Agent to generate these:
+
+# Fist, we need a secret value to sign access tokens.
+# You can use the generate_secret tool included with Agent to generate this:
+
+# > make generate_secret
+# Client Secret: CvzvkWm3V1D9RBxPWEjC+ud9zvwcOvnnLkWaIkzDGyA=
+
+# You can ignore the second line that says "Client Secret's hash".
+
+# Then, set an environment variable to make this secret available to Agent:
+# > export OPTIMIZELY_API_AUTH_HMACSECRETS=CvzvkWm3V1D9RBxPWEjC+ud9zvwcOvnnLkWaIkzDGyA=
+
+# Next, we need client credentials (ID & secret), and the BCrypt hash of our secret
+# Again, you can use the generate_secret tool included with Agent to generate these:
 #
 # > make generate_secret
 # Client Secret: 0bfLVX9U3Lpr6Qe4X3DSSIWNqEkEQ4bkX1WZ5Km6spM=
 # Client Secret's hash: JDJhJDEyJEdkSHpicHpRODBqOC9FQzRneGIyNXU0ZFVPMFNKcUhkdTRUQXRzWUJOdjRzRmcuVGdFUTUu
 #
-# Take the hash, and add it to your agent configuration file (default: config.yaml) under the "api" section:
+# Take the hash, and add it to your agent configuration file (default: config.yaml) under the "api" section,
+# along with your desired client ID and SDK key:
 #
 # auth:
 #   ttl: 30m
 #   clients:
 #     - id: clientid1
 #       secretHash: JDJhJDEyJEdkSHpicHpRODBqOC9FQzRneGIyNXU0ZFVPMFNKcUhkdTRUQXRzWUJOdjRzRmcuVGdFUTUu
-#
-# Then, set an environment variable for the signing secret that Agent will use to sign access tokens:
-#
-# > export OPTIMIZELY_API_AUTH_HMACSECRETS=llmO3xTUx+6TIfUU6eXmH/1Fh44ioL0h87G1iSrd5Gg
+#       sdkKeys:
+#           - <Your SDK Key>
+
 #
 # Start Agent with the API interface running on the default port (8080).
 # Then, finally, run the example, passing your SDK key, client ID and secret:
-# > python auth.py <Your SDK Key> <Your Client ID> 0bfLVX9U3Lpr6Qe4X3DSSIWNqEkEQ4bkX1WZ5Km6spM=
+# > python auth.py <Your SDK Key> clientid1 0bfLVX9U3Lpr6Qe4X3DSSIWNqEkEQ4bkX1WZ5Km6spM=
 #
 # For more information, see docs/auth.md
 
@@ -46,11 +57,11 @@ s.headers.update({'X-Optimizely-SDK-Key': sdk_key})
 resp = s.get('http://localhost:8080/v1/config')
 print('first config request, not including access token: response status = {}'.format(resp.status_code))
 
-resp = s.post('http://localhost:8080/oauth/token', data=json.dumps({
+resp = s.post('http://localhost:8080/oauth/token', data={
     'grant_type': 'client_credentials',
     'client_id':  client_id,
     'client_secret': client_secret,
-}))
+})
 resp_dict = resp.json()
 print('access token response: ')
 print(json.dumps(resp_dict, indent=4, sort_keys=True))

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -89,8 +89,6 @@ func NewOAuthHandler(authConfig *config.ServiceAuthConfig) *OAuthHandler {
 	}
 
 	h := &OAuthHandler{
-		// TODO: Interpret hmacSecret as a base64-format string, since we are already doing that for
-		// client secrets
 		hmacSecret:        []byte(hmacSecret),
 		ClientCredentials: clientCredentials,
 	}

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -68,12 +68,11 @@ func NewOAuthHandler(authConfig *config.ServiceAuthConfig) *OAuthHandler {
 		if err != nil {
 			log.Error().Err(err).Msgf("error decoding client creds secret (paired with client ID: %v), skipping these credentials", clientCreds.ID)
 			continue
-
 		}
+
 		if len(clientCreds.SDKKeys) == 0 {
 			log.Error().Err(err).Msgf("client creds missing or empty SDK keys (with client ID: %v), skipping these credentials", clientCreds.ID)
 			continue
-
 		}
 
 		clientCredentials[clientCreds.ID] = ClientCredentials{

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -89,6 +89,8 @@ func NewOAuthHandler(authConfig *config.ServiceAuthConfig) *OAuthHandler {
 	}
 
 	h := &OAuthHandler{
+		// TODO: Interpret hmacSecret as a base64-format string, since we are already doing that for
+		// client secrets
 		hmacSecret:        []byte(hmacSecret),
 		ClientCredentials: clientCredentials,
 	}

--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -18,6 +18,7 @@
 package handlers
 
 import (
+	"fmt"
 	"net/http"
 	"time"
 
@@ -34,18 +35,13 @@ type ClientCredentials struct {
 	ID         string
 	TTL        time.Duration
 	SecretHash []byte
+	SDKKeys    []string
 }
 
 // OAuthHandler provides handler for auth
 type OAuthHandler struct {
 	ClientCredentials map[string]ClientCredentials
 	hmacSecret        []byte
-}
-
-type tokenRequest struct {
-	GrantType    string `json:"grant_type"`
-	ClientID     string `json:"client_id"`
-	ClientSecret string `json:"client_secret"`
 }
 
 type tokenResponse struct {
@@ -70,13 +66,21 @@ func NewOAuthHandler(authConfig *config.ServiceAuthConfig) *OAuthHandler {
 	for _, clientCreds := range authConfig.Clients {
 		secretHashBytes, err := jwtauth.DecodeSecretHashFromConfig(clientCreds.SecretHash)
 		if err != nil {
-			log.Error().Err(err).Msgf("error decoding client creds secret (paired with client ID: %v)", clientCreds.ID)
+			log.Error().Err(err).Msgf("error decoding client creds secret (paired with client ID: %v), skipping these credentials", clientCreds.ID)
 			continue
+
 		}
+		if len(clientCreds.SDKKeys) == 0 {
+			log.Error().Err(err).Msgf("client creds missing or empty SDK keys (with client ID: %v), skipping these credentials", clientCreds.ID)
+			continue
+
+		}
+
 		clientCredentials[clientCreds.ID] = ClientCredentials{
 			ID:         clientCreds.ID,
 			SecretHash: secretHashBytes,
 			TTL:        authConfig.TTL,
+			SDKKeys:    clientCreds.SDKKeys,
 		}
 	}
 
@@ -109,38 +113,52 @@ func (err *ClientCredentialsError) Error() string {
 }
 
 func (h *OAuthHandler) verifyClientCredentials(r *http.Request) (*ClientCredentials, int, error) {
-	var reqBody tokenRequest
-	err := ParseRequestBody(r, &reqBody)
-	if err != nil {
-		return nil, http.StatusBadRequest, err
+	reqContentType := render.GetContentType(r.Header.Get("Content-Type"))
+	if reqContentType != render.ContentTypeForm {
+		return nil, http.StatusBadRequest, &ClientCredentialsError{
+			ErrorCode:        "invalid_request",
+			ErrorDescription: "Content-Type header value must be application/x-www-form-urlencoded",
+		}
 	}
 
-	if reqBody.GrantType == "" {
+	err := r.ParseForm()
+	if err != nil {
+		return nil, http.StatusBadRequest, &ClientCredentialsError{
+			ErrorCode:        "invalid_request",
+			ErrorDescription: fmt.Sprintf("error parsing request body: %v", err.Error()),
+		}
+	}
+
+	grantType := r.PostFormValue("grant_type")
+	clientID := r.PostFormValue("client_id")
+	clientSecret := r.PostFormValue("client_secret")
+
+	if grantType == "" {
 		return nil, http.StatusBadRequest, &ClientCredentialsError{
 			ErrorCode:        "invalid_request",
 			ErrorDescription: "grant_type missing from request body",
 		}
 	}
-	if reqBody.GrantType != "client_credentials" {
+	if grantType != "client_credentials" {
 		return nil, http.StatusBadRequest, &ClientCredentialsError{
 			ErrorCode: "unsupported_grant_type",
 		}
 	}
 
-	if reqBody.ClientID == "" {
+	if clientID == "" {
 		return nil, http.StatusUnauthorized, &ClientCredentialsError{
 			ErrorCode:        "invalid_client",
 			ErrorDescription: "client_id missing from request body",
 		}
 	}
 
-	if reqBody.ClientSecret == "" {
+	if clientSecret == "" {
 		return nil, http.StatusUnauthorized, &ClientCredentialsError{
 			ErrorCode:        "invalid_client",
 			ErrorDescription: "client_secret missing from request body",
 		}
 	}
-	clientCreds, ok := h.ClientCredentials[reqBody.ClientID]
+	clientCreds, ok := h.ClientCredentials[clientID]
 	if !ok {
 		return nil, http.StatusUnauthorized, &ClientCredentialsError{
 			ErrorCode:        "invalid_client",
@@ -148,7 +166,7 @@ func (h *OAuthHandler) verifyClientCredentials(r *http.Request) (*ClientCredenti
 		}
 	}
 
-	isValid, err := jwtauth.ValidateClientSecret(reqBody.ClientSecret, clientCreds.SecretHash)
+	isValid, err := jwtauth.ValidateClientSecret(clientSecret, clientCreds.SecretHash)
 	if err != nil {
 		middleware.GetLogger(r).Info().Err(err).Msg("validating request secret")
 	}
@@ -177,16 +195,7 @@ func (h *OAuthHandler) CreateAPIAccessToken(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	sdkKey := r.Header.Get(middleware.OptlySDKHeader)
-	if sdkKey == "" {
-		renderClientCredentialsError(&ClientCredentialsError{
-			ErrorCode:        "invalid_request",
-			ErrorDescription: "X-Optimizely-Sdk-Key header required",
-		}, http.StatusBadRequest, w, r)
-		return
-	}
-
-	accessToken, err := jwtauth.BuildAPIAccessToken(sdkKey, clientCreds.TTL, h.hmacSecret)
+	accessToken, err := jwtauth.BuildAPIAccessToken(clientCreds.SDKKeys, clientCreds.TTL, h.hmacSecret)
 	if err != nil {
 		middleware.GetLogger(r).Error().Err(err).Msg("Calling jwt BuildAPIAccessToken")
 		RenderError(err, http.StatusInternalServerError, w, r)

--- a/pkg/handlers/oauth_test.go
+++ b/pkg/handlers/oauth_test.go
@@ -18,14 +18,14 @@
 package handlers
 
 import (
-	"bytes"
 	"encoding/json"
 	"github.com/go-chi/chi"
 	"github.com/optimizely/agent/config"
-	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 )
@@ -39,17 +39,18 @@ type OAuthTestSuite struct {
 
 func (s *OAuthTestSuite) SetupTest() {
 	s.secret = "RW+Uo/7z4ag9hAb10w8LIZFRFaSwS4nt1/l+uVgChIQ="
-	config := config.ServiceAuthConfig{
+	authConfig := config.ServiceAuthConfig{
 		Clients: []config.OAuthClientCredentials{
 			{
 				ID:         "optly_user",
 				SecretHash: "JDJhJDEyJDNDOG12LmNCNzlHaHhGcEJtLzZZQk9VLnRneEpGTTlnTXozb2kyNS9ERzhJTDZOZkpGa0ND",
+				SDKKeys:    []string{"123"},
 			},
 		},
 		HMACSecrets: []string{"hmac_seekrit"},
 		TTL:         30 * time.Minute,
 	}
-	s.handler = NewOAuthHandler(&config)
+	s.handler = NewOAuthHandler(&authConfig)
 
 	mux := chi.NewMux()
 	mux.Post("/api/token", s.handler.CreateAPIAccessToken)
@@ -58,178 +59,158 @@ func (s *OAuthTestSuite) SetupTest() {
 }
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenMissingGrantType() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"client_id":     "optly",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("client_id", "optly")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenMissingGrantType() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"client_id":     "optly",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("client_id", "optly")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenUnsupportedGrantType() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "authorization",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "authorization")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenUnsupportedGrantType() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "authorization",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "authorization")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenMissingClientId() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenMissingClientId() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenMissingClientSecret() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type": "client_credentials",
-		"client_id":  "optly_user",
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenMissingClientSecret() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type": "client_credentials",
-		"client_id":  "optly_user",
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenInvalidClientId() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "not_an_optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "not_an_optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenInvalidClientId() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "not_an_optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "not_an_optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenInvalidClientSecret() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": "invalid_seekret",
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", "GpDgQx7w8Hb3ibD6K+T77S/0kHgr9qoRxsEpC2lDv08=")
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenInvalidClientSecret() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": "invalid_seekret",
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", "GpDgQx7w8Hb3ibD6K+T77S/0kHgr9qoRxsEpC2lDv08=")
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
-func (s *OAuthTestSuite) TestGetAPIAccessTokenMissingSDKKey() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	rec := httptest.NewRecorder()
-	s.mux.ServeHTTP(rec, req)
-	s.Equal(http.StatusBadRequest, rec.Code)
-}
-
 func (s *OAuthTestSuite) TestGetAPIAccessTokenInvalidBody() {
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader([]byte("<><**")))
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader("fjklM<>CXM><&&^&%"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusBadRequest, rec.Code)
 }
-
 
 func (s *OAuthTestSuite) TestGetAPIAccessTokenSuccess() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
-	req.Header.Set(middleware.OptlySDKHeader, "123")
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 
@@ -243,12 +224,12 @@ func (s *OAuthTestSuite) TestGetAPIAccessTokenSuccess() {
 }
 
 func (s *OAuthTestSuite) TestGetAdminAccessTokenSuccess() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": s.secret,
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 
@@ -272,12 +253,12 @@ type OAuthDisabledTestSuite struct {
 }
 
 func (s *OAuthDisabledTestSuite) SetupTest() {
-	config := config.ServiceAuthConfig{
+	authConfig := config.ServiceAuthConfig{
 		Clients:     make([]config.OAuthClientCredentials, 0),
 		HMACSecrets: make([]string, 0),
 		TTL:         0,
 	}
-	s.handler = NewOAuthHandler(&config)
+	s.handler = NewOAuthHandler(&authConfig)
 
 	mux := chi.NewMux()
 	mux.Post("/api/token", s.handler.CreateAPIAccessToken)
@@ -286,24 +267,24 @@ func (s *OAuthDisabledTestSuite) SetupTest() {
 }
 
 func (s *OAuthDisabledTestSuite) TestGetAdminAccessTokenDisabled() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": "client_seekrit",
-	})
-	req := httptest.NewRequest("POST", "/admin/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", "client_seekrit")
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
 }
 
 func (s *OAuthDisabledTestSuite) TestGetAPIAccessTokenDisabled() {
-	bodyBytes, _ := json.Marshal(map[string]string{
-		"grant_type":    "client_credentials",
-		"client_id":     "optly_user",
-		"client_secret": "client_seekrit",
-	})
-	req := httptest.NewRequest("POST", "/api/token", bytes.NewReader(bodyBytes))
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", "client_seekrit")
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	rec := httptest.NewRecorder()
 	s.mux.ServeHTTP(rec, req)
 	s.Equal(http.StatusUnauthorized, rec.Code)
@@ -327,6 +308,7 @@ func (s *OAuthMissingHMACSecretTestSuite) SetupTest() {
 			{
 				ID:         "optly_user",
 				SecretHash: "JDJhJDEyJDNDOG12LmNCNzlHaHhGcEJtLzZZQk9VLnRneEpGTTlnTXozb2kyNS9ERzhJTDZOZkpGa0ND",
+				SDKKeys:    []string{"123"},
 			},
 		},
 		// No HMACSecrets provided - this configuration is invalid

--- a/pkg/jwtauth/jwtauth.go
+++ b/pkg/jwtauth/jwtauth.go
@@ -28,12 +28,12 @@ import (
 )
 
 // BuildAPIAccessToken returns a token for accessing the API service using the argument SDK key and TTL. It also returns the expiration timestamp.
-func BuildAPIAccessToken(sdkKey string, ttl time.Duration, key []byte) (tokenString string, err error) {
+func BuildAPIAccessToken(sdkKeys []string, ttl time.Duration, key []byte) (tokenString string, err error) {
 	expires := time.Now().Add(ttl).Unix()
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
 		"iss":     "Optimizely",
-		"sdk_key": sdkKey,
+		"sdk_keys": sdkKeys,
 		"exp":     expires,
 	})
 	tokenString, err = token.SignedString(key)

--- a/pkg/jwtauth/jwtauth.go
+++ b/pkg/jwtauth/jwtauth.go
@@ -27,7 +27,7 @@ import (
 	"github.com/dgrijalva/jwt-go"
 )
 
-// BuildAPIAccessToken returns a token for accessing the API service using the argument SDK key and TTL. It also returns the expiration timestamp.
+// BuildAPIAccessToken returns a token for accessing the API service using the argument SDK keys and TTL. It also returns the expiration timestamp.
 func BuildAPIAccessToken(sdkKeys []string, ttl time.Duration, key []byte) (tokenString string, err error) {
 	expires := time.Now().Add(ttl).Unix()
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -277,25 +277,21 @@ func (a Auth) AuthorizeAPI(next http.Handler) http.Handler {
 				RenderError(errors.New("Invalid claims: sdk_keys not found, or have the wrong type"), http.StatusUnauthorized, w, r)
 				return
 			}
-			claimsSdkKeys := make([]string, len(rawClaimsSdkKeys))
-			for i, rawSdkKey := range rawClaimsSdkKeys {
+			sdkKeyFromHeader := r.Header.Get(OptlySDKHeader)
+			foundMatchingSdkKey := false
+			for _, rawSdkKey := range rawClaimsSdkKeys {
 				sdkKey, ok := rawSdkKey.(string)
 				if !ok {
 					// TODO: log
 					continue
 				}
-				claimsSdkKeys[i] = sdkKey
-			}
-			sdkKeyFromHeader := r.Header.Get(OptlySDKHeader)
-			foundMatchingSdkKey := false
-			for _, sdkKey := range claimsSdkKeys {
 				if sdkKey == sdkKeyFromHeader {
 					foundMatchingSdkKey = true
 					break
 				}
 			}
 			if !foundMatchingSdkKey {
-				RenderError(fmt.Errorf("SDK key %v, given in X-Optimizely-Sdk-Key header, was not found in the SDK keys in this token's claims (%v)", sdkKeyFromHeader, claimsSdkKeys), http.StatusUnauthorized, w, r)
+				RenderError(errors.New("SDK key given in X-Optimizely-Sdk-Key header was not found in the SDK keys in this token's claims"), http.StatusUnauthorized, w, r)
 				return
 			}
 		}

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -282,7 +282,7 @@ func (a Auth) AuthorizeAPI(next http.Handler) http.Handler {
 			for _, rawSdkKey := range rawClaimsSdkKeys {
 				sdkKey, ok := rawSdkKey.(string)
 				if !ok {
-					// TODO: log
+					GetLogger(r).Warn().Msgf("Non-string value in token claims sdk_keys: %v", sdkKey)
 					continue
 				}
 				if sdkKey == sdkKeyFromHeader {

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -274,7 +274,7 @@ func (a Auth) AuthorizeAPI(next http.Handler) http.Handler {
 
 			rawClaimsSdkKeys, ok := claims["sdk_keys"].([]interface{})
 			if !ok {
-				RenderError(errors.New("Invalid claims: sdk_keys not found, or have the wrong type"), http.StatusUnauthorized, w, r)
+				RenderError(errors.New("invalid claims: sdk_keys not found, or have the wrong type"), http.StatusUnauthorized, w, r)
 				return
 			}
 			sdkKeyFromHeader := r.Header.Get(OptlySDKHeader)

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -117,10 +117,11 @@ func WithAPIRouter(opt *APIOptions, r chi.Router) {
 		r.Use(chimw.Throttle(opt.maxConns))
 	}
 
-	r.Use(middleware.SetTime, opt.sdkMiddleware)
+	r.Use(middleware.SetTime)
 	r.Use(render.SetContentType(render.ContentTypeJSON), middleware.SetRequestID)
 
 	r.Route("/v1", func(r chi.Router) {
+		r.Use(opt.sdkMiddleware)
 		r.With(getConfigTimer, opt.oAuthMiddleware).Get("/config", opt.configHandler)
 		r.With(activateTimer, opt.oAuthMiddleware).Post("/activate", opt.activateHandler)
 		r.With(trackTimer, opt.oAuthMiddleware).Post("/track", opt.trackHandler)

--- a/pkg/routers/api_test.go
+++ b/pkg/routers/api_test.go
@@ -122,7 +122,6 @@ func (suite *APIV1TestSuite) TestCreateAccessToken() {
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
 	suite.Equal(http.StatusOK, rec.Code)
-	suite.Equal("expected", rec.Header().Get(clientHeaderKey))
 	suite.Equal("oauth/token", rec.Header().Get(methodHeaderKey))
 }
 
@@ -142,6 +141,7 @@ func TestNewDefaultAPIV1RouterInvalidHandlerConfig(t *testing.T) {
 				{
 					ID:         "id1",
 					SecretHash: "JDJhJDEyJFBQM3dSdnNERnVSQmZPNnA4MGcvLk9Eb1RVWExYMm5FZ2VhZXpsS1VmR3hPdFJUT3ViaXVX",
+					SDKKeys:    []string{"123"},
 				},
 			},
 			// Empty HMACSecrets, but non-empty Clients, is an invalid config


### PR DESCRIPTION
## Summary
`X-Optimziely-Sdk-Key` header is no longer required by token issuer endpoint. Instead, SDK keys are given in configuration of clients. 1 or more SDK keys are required for each client.

## JIRA
https://optimizely.atlassian.net/browse/OASIS-6073
