### PR TITLE
feat(override): adds override response body

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -87,12 +87,16 @@ paths:
         in memory for debugging and testing purposes and should not be used
         for production overrides.
       responses:
-        '201':
-          description: Forced variation set
-        '204':
-          description: Forced variation was already set
+        '200':
+          description: Valid response
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Override'
         '400':
-          description: Invalid user id, experiment key, or variation key
+          description: Invalid payload
         '401':
           description: Unauthorized, invalid JWT
         '403':
@@ -273,6 +277,20 @@ components:
         userAttributes:
           type: object
           additionalProperties: true
+    Override:
+      properties:
+        userId:
+          type: string
+        experimentKey:
+          type: string
+        variationKey:
+          type: string
+        prevVariationKey:
+          type: string
+        messages:
+          type: array
+          items:
+            type: string
     OverrideContext:
       type: array
       items:

--- a/pkg/handlers/override.go
+++ b/pkg/handlers/override.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 
 	"github.com/optimizely/agent/pkg/middleware"
+	"github.com/optimizely/agent/pkg/optimizely"
 )
 
 // OverrideBody defines the request body for an override
@@ -41,8 +42,8 @@ func Override(w http.ResponseWriter, r *http.Request) {
 	}
 
 	var body OverrideBody
-	if ParseRequestBody(r, &body) != nil {
-		RenderError(err, http.StatusInternalServerError, w, r)
+	if parseErr := ParseRequestBody(r, &body); parseErr != nil {
+		RenderError(parseErr, http.StatusBadRequest, w, r)
 		return
 	}
 
@@ -71,6 +72,8 @@ func Override(w http.ResponseWriter, r *http.Request) {
 	logger.Debug().Str("experimentKey", experimentKey).Str("variationKey", body.VariationKey).Msg("setting override")
 	wasSet, err := optlyClient.SetForcedVariation(experimentKey, body.UserID, body.VariationKey)
 	switch {
+	case errors.Is(err, optimizely.ErrEntityNotFound):
+		RenderError(err, http.StatusBadRequest, w, r)
 	case err != nil:
 		RenderError(err, http.StatusInternalServerError, w, r)
 	case wasSet:

--- a/pkg/handlers/override.go
+++ b/pkg/handlers/override.go
@@ -61,12 +61,11 @@ func Override(w http.ResponseWriter, r *http.Request) {
 
 	// Empty variation means remove
 	if body.VariationKey == "" {
-		err = optlyClient.RemoveForcedVariation(experimentKey, body.UserID)
-		if err != nil {
+		if override, err := optlyClient.RemoveForcedVariation(experimentKey, body.UserID); err != nil {
 			RenderError(err, http.StatusInternalServerError, w, r)
-			return
+		} else {
+			render.JSON(w, r, override)
 		}
-		w.WriteHeader(http.StatusNoContent)
 		return
 	}
 

--- a/pkg/handlers/override_test.go
+++ b/pkg/handlers/override_test.go
@@ -68,6 +68,8 @@ func (suite *OverrideTestSuite) SetupTest() {
 	testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "variation_disabled", "variation_enabled")
 	featureExp := testClient.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
 
+	testClient.AddExperimentWithVariations("valid", "valid")
+
 	ab := OverrideBody{
 		UserID:        "testUser",
 		ExperimentKey: featureExp.Key,
@@ -110,16 +112,24 @@ func (suite *OverrideTestSuite) TestSetForcedVariation() {
 }
 
 func (suite *OverrideTestSuite) TestSetForcedVariationInvalidPayload() {
-	invalid := []OverrideBody{
+	invalid := []map[string]interface{}{
 		{
-			UserID:        "",
-			ExperimentKey: "valid",
-			VariationKey:  "variation_enabled",
+			"userID":        "",
+			"experimentKey": "valid",
+			"variationKey":  "valid",
 		},
 		{
-			UserID:        "valid",
-			ExperimentKey: "",
-			VariationKey:  "variation_enabled",
+			"userID":        "valid",
+			"experimentKey": "",
+			"variationKey":  "valid",
+		},
+		{
+			"userID":        "valid",
+			"experimentKey": "not-valid",
+			"variationKey":  "valid",
+		},
+		{
+			"userId": true,
 		},
 	}
 

--- a/pkg/handlers/override_test.go
+++ b/pkg/handlers/override_test.go
@@ -145,6 +145,16 @@ func (suite *OverrideTestSuite) TestValidOverrides() {
 func (suite *OverrideTestSuite) TestInvalidOverrides() {
 	invalid := []map[string]interface{}{
 		{
+			"userID":        "",
+			"experimentKey": "valid",
+			"variationKey":  "valid",
+		},
+		{
+			"userID":        "valid",
+			"experimentKey": "",
+			"variationKey":  "valid",
+		},
+		{
 			"userId": true,
 		},
 	}

--- a/pkg/handlers/override_test.go
+++ b/pkg/handlers/override_test.go
@@ -90,7 +90,7 @@ func (suite *OverrideTestSuite) TestSetForcedVariation() {
 	req := httptest.NewRequest("POST", "/override", bytes.NewBuffer(suite.body))
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusCreated, rec.Code)
+	suite.Equal(http.StatusOK, rec.Code)
 
 	key := decision.ExperimentOverrideKey{
 		ExperimentKey: suite.experimentKey,
@@ -104,7 +104,7 @@ func (suite *OverrideTestSuite) TestSetForcedVariation() {
 	req = httptest.NewRequest("POST", "/override", bytes.NewBuffer(suite.body))
 	rec = httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
-	suite.Equal(http.StatusNoContent, rec.Code)
+	suite.Equal(http.StatusOK, rec.Code)
 
 	actual, ok = suite.tc.ForcedVariations.GetVariation(key)
 	suite.True(ok)
@@ -113,21 +113,21 @@ func (suite *OverrideTestSuite) TestSetForcedVariation() {
 
 func (suite *OverrideTestSuite) TestSetForcedVariationInvalidPayload() {
 	invalid := []map[string]interface{}{
-		{
-			"userID":        "",
-			"experimentKey": "valid",
-			"variationKey":  "valid",
-		},
-		{
-			"userID":        "valid",
-			"experimentKey": "",
-			"variationKey":  "valid",
-		},
-		{
-			"userID":        "valid",
-			"experimentKey": "not-valid",
-			"variationKey":  "valid",
-		},
+		//{
+		//	"userID":        "",
+		//	"experimentKey": "valid",
+		//	"variationKey":  "valid",
+		//},
+		//{
+		//	"userID":        "valid",
+		//	"experimentKey": "",
+		//	"variationKey":  "valid",
+		//},
+		//{
+		//	"userID":        "valid",
+		//	"experimentKey": "not-valid",
+		//	"variationKey":  "valid",
+		//},
 		{
 			"userId": true,
 		},

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -50,6 +50,15 @@ type Decision struct {
 	Error         string                 `json:"error"`
 }
 
+// Override model
+type Override struct {
+	UserID           string   `json:"userId"`
+	ExperimentKey    string   `json:"experimentKey"`
+	VariationKey     string   `json:"variationKey"`
+	PrevVariationKey string   `json:"prevVariationKey"`
+	Messages         []string `json:"messages"`
+}
+
 // UpdateConfig uses config manager to sync and set project config
 func (c *OptlyClient) UpdateConfig() {
 	if c.ConfigManager != nil {
@@ -74,18 +83,25 @@ func (c *OptlyClient) TrackEvent(eventKey string, uc entities.UserContext, event
 // SetForcedVariation sets a forced variation for the argument experiment key and user ID
 // Returns false if the same forced variation was already set for the argument experiment and user, true otherwise
 // Returns an error when forced variations are not available on this OptlyClient instance
-func (c *OptlyClient) SetForcedVariation(experimentKey, userID, variationKey string) (bool, error) {
+func (c *OptlyClient) SetForcedVariation(experimentKey, userID, variationKey string) (*Override, error) {
 	if c.ForcedVariations == nil {
-		return false, ErrForcedVariationsUninitialized
+		return &Override{}, ErrForcedVariationsUninitialized
 	}
 
+	override := Override{
+		UserID:        userID,
+		ExperimentKey: experimentKey,
+		VariationKey:  variationKey,
+	}
+
+	messages := make([]string, 0, 2)
 	// Check the entities exist as part of the Optimizely configuration
 	if optimizelyConfig := c.GetOptimizelyConfig(); optimizelyConfig == nil {
-		return false, errors.New("optimizely config is null")
+		messages = append(messages, "override cannot be validated via configuration")
 	} else if experiment, ok := optimizelyConfig.ExperimentsMap[experimentKey]; !ok {
-		return false, fmt.Errorf("experimentKey: %q %w", experimentKey, ErrEntityNotFound)
+		messages = append(messages, "experimentKey not found in configuration")
 	} else if _, ok := experiment.VariationsMap[variationKey]; !ok {
-		return false, fmt.Errorf("variationKey: %q %w", variationKey, ErrEntityNotFound)
+		messages = append(messages, "variationKey not found in configuration")
 	}
 
 	forcedVariationKey := decision.ExperimentOverrideKey{
@@ -93,10 +109,17 @@ func (c *OptlyClient) SetForcedVariation(experimentKey, userID, variationKey str
 		ExperimentKey: experimentKey,
 	}
 
-	previousVariationKey, ok := c.ForcedVariations.GetVariation(forcedVariationKey)
+	if prevVariationKey, ok := c.ForcedVariations.GetVariation(forcedVariationKey); ok {
+		override.PrevVariationKey = prevVariationKey
+		messages = append(messages, "updating previous override")
+	}
+
+	if len(messages) > 0 {
+		override.Messages = messages
+	}
+
 	c.ForcedVariations.SetVariation(forcedVariationKey, variationKey)
-	wasSet := !ok || previousVariationKey != variationKey
-	return wasSet, nil
+	return &override, nil
 }
 
 // RemoveForcedVariation removes any forced variation that was previously set for the argument experiment key and user ID

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -78,10 +78,21 @@ func (c *OptlyClient) SetForcedVariation(experimentKey, userID, variationKey str
 	if c.ForcedVariations == nil {
 		return false, ErrForcedVariationsUninitialized
 	}
+
+	// Check the entities exist as part of the Optimizely configuration
+	if optimizelyConfig := c.GetOptimizelyConfig(); optimizelyConfig == nil {
+		return false, errors.New("optimizely config is null")
+	} else if experiment, ok := optimizelyConfig.ExperimentsMap[experimentKey]; !ok {
+		return false, fmt.Errorf("experimentKey: %q %w", experimentKey, ErrEntityNotFound)
+	} else if _, ok := experiment.VariationsMap[variationKey]; !ok {
+		return false, fmt.Errorf("variationKey: %q %w", variationKey, ErrEntityNotFound)
+	}
+
 	forcedVariationKey := decision.ExperimentOverrideKey{
 		UserID:        userID,
 		ExperimentKey: experimentKey,
 	}
+
 	previousVariationKey, ok := c.ForcedVariations.GetVariation(forcedVariationKey)
 	c.ForcedVariations.SetVariation(forcedVariationKey, variationKey)
 	wasSet := !ok || previousVariationKey != variationKey

--- a/pkg/optimizely/client_test.go
+++ b/pkg/optimizely/client_test.go
@@ -110,6 +110,19 @@ func (suite *ClientTestSuite) TestSetForcedVariationDifferentVariation() {
 	suite.True(isEnabled)
 }
 
+func (suite *ClientTestSuite) TestSetForcedVariationMissingExperiment() {
+	wasSet, err := suite.optlyClient.SetForcedVariation("does-not-exist", "userId", "disabled_var")
+	suite.False(wasSet)
+	suite.EqualError(err, `experimentKey: "does-not-exist" not found`)
+}
+
+func (suite *ClientTestSuite) TestSetForcedVariationMissingVariation() {
+	suite.testClient.AddExperimentWithVariations("my_exp", "my_var")
+	wasSet, err := suite.optlyClient.SetForcedVariation("my_exp", "userId", "does-not-exist")
+	suite.False(wasSet)
+	suite.EqualError(err, `variationKey: "does-not-exist" not found`)
+}
+
 func (suite *ClientTestSuite) TestRemoveForcedVariation() {
 	feature := entities.Feature{Key: "my_feat"}
 	suite.testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "disabled_var", "enabled_var")

--- a/pkg/optimizely/client_test.go
+++ b/pkg/optimizely/client_test.go
@@ -23,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/optimizely/go-sdk/pkg/client"
+	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/notification"
 	"github.com/stretchr/testify/assert"
 
@@ -35,6 +36,7 @@ import (
 
 type ClientTestSuite struct {
 	suite.Suite
+	featureExp  entities.Experiment
 	optlyClient *OptlyClient
 	userContext entities.UserContext
 	testClient  *optimizelytest.TestClient
@@ -43,6 +45,9 @@ type ClientTestSuite struct {
 func (suite *ClientTestSuite) SetupTest() {
 	testClient := optimizelytest.NewClient()
 	suite.testClient = testClient
+	feature := entities.Feature{Key: "my_feat"}
+	suite.testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "disabled_var", "enabled_var")
+	suite.featureExp = suite.testClient.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
 	suite.optlyClient = &OptlyClient{
 		OptimizelyClient: testClient.OptimizelyClient,
 		ConfigManager:    &MockConfigManager{config: testClient.ProjectConfig},
@@ -73,73 +78,65 @@ func (suite *ClientTestSuite) TestTrackEvent() {
 	suite.Equal(tags, actual.Conversion.Tags)
 }
 
-func (suite *ClientTestSuite) TestSetForcedVariationSuccess() {
-	feature := entities.Feature{Key: "my_feat"}
-	suite.testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "disabled_var", "enabled_var")
-	featureExp := suite.testClient.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
-	actual, err := suite.optlyClient.SetForcedVariation(featureExp.Key, "userId", "enabled_var")
-	suite.NoError(err)
-	suite.Equal(actual.UserID, "userId")
-	suite.Equal(actual.ExperimentKey, featureExp.Key)
-	suite.Equal(actual.VariationKey, "enabled_var")
-	suite.Empty(actual.PrevVariationKey)
-	isEnabled, _ := suite.optlyClient.IsFeatureEnabled("my_feat", suite.userContext)
-	suite.True(isEnabled)
-}
+func (suite *ClientTestSuite) TestValidSetForcedVariations() {
+	scenarios := []struct {
+		experimentKey string
+		variationKey  string
+		previousKey   string
+		messages      []string
+	}{
+		{
+			experimentKey: suite.featureExp.Key,
+			variationKey:  "enabled_var",
+			previousKey:   "",
+			messages:      nil,
+		},
+		{
+			experimentKey: suite.featureExp.Key,
+			variationKey:  "disabled_var",
+			previousKey:   "enabled_var",
+			messages:      []string{"updating previous override"},
+		},
+		{
+			experimentKey: suite.featureExp.Key,
+			variationKey:  "dne-var",
+			previousKey:   "disabled_var",
+			messages: []string{
+				"variationKey not found in configuration",
+				"updating previous override",
+			},
+		},
+		{
+			experimentKey: "dne-exp",
+			variationKey:  "dne-var",
+			previousKey:   "",
+			messages:      []string{"experimentKey not found in configuration"},
+		},
+	}
 
-func (suite *ClientTestSuite) TestSetForcedVariationAlreadySet() {
-	feature := entities.Feature{Key: "my_feat"}
-	suite.testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "disabled_var", "enabled_var")
-	featureExp := suite.testClient.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
-	suite.optlyClient.SetForcedVariation(featureExp.Key, "userId", "enabled_var")
-	// Set the same forced variation again
-	actual, err := suite.optlyClient.SetForcedVariation(featureExp.Key, "userId", "enabled_var")
-	suite.NoError(err)
-	suite.Equal(actual.UserID, "userId")
-	suite.Equal(actual.ExperimentKey, featureExp.Key)
-	suite.Equal(actual.VariationKey, "enabled_var")
-	suite.Equal(actual.PrevVariationKey, "enabled_var")
-	suite.Equal([]string{"updating previous override"}, actual.Messages)
-	isEnabled, _ := suite.optlyClient.IsFeatureEnabled("my_feat", suite.userContext)
-	suite.True(isEnabled)
-}
+	userId := "testUser"
+	for _, scenario := range scenarios {
+		actual, err := suite.optlyClient.SetForcedVariation(scenario.experimentKey, userId, scenario.variationKey)
+		suite.NoError(err)
 
-func (suite *ClientTestSuite) TestSetForcedVariationDifferentVariation() {
-	feature := entities.Feature{Key: "my_feat"}
-	suite.testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "disabled_var", "enabled_var")
-	featureExp := suite.testClient.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
-	suite.optlyClient.SetForcedVariation(featureExp.Key, "userId", "disabled_var")
-	// Set a different forced variation
-	actual, err := suite.optlyClient.SetForcedVariation(featureExp.Key, "userId", "enabled_var")
-	suite.NoError(err)
-	suite.Equal(actual.UserID, "userId")
-	suite.Equal(actual.ExperimentKey, featureExp.Key)
-	suite.Equal(actual.VariationKey, "enabled_var")
-	suite.Equal(actual.PrevVariationKey, "disabled_var")
-	suite.Equal([]string{"updating previous override"}, actual.Messages)
-	isEnabled, _ := suite.optlyClient.IsFeatureEnabled("my_feat", suite.userContext)
-	suite.True(isEnabled)
-}
+		expected := &Override{
+			UserID:           userId,
+			ExperimentKey:    scenario.experimentKey,
+			VariationKey:     scenario.variationKey,
+			PrevVariationKey: scenario.previousKey,
+			Messages:         scenario.messages,
+		}
 
-func (suite *ClientTestSuite) TestSetForcedVariationMissingExperiment() {
-	actual, err := suite.optlyClient.SetForcedVariation("does-not-exist", "userId", "disabled_var")
-	suite.NoError(err)
-	suite.Equal(actual.UserID, "userId")
-	suite.Equal(actual.ExperimentKey, "does-not-exist")
-	suite.Equal(actual.VariationKey, "disabled_var")
-	suite.Empty(actual.PrevVariationKey)
-	suite.Equal([]string{"experimentKey not found in configuration"}, actual.Messages)
-}
+		suite.Equal(expected, actual)
 
-func (suite *ClientTestSuite) TestSetForcedVariationMissingVariation() {
-	suite.testClient.AddExperimentWithVariations("my_exp", "my_var")
-	actual, err := suite.optlyClient.SetForcedVariation("my_exp", "userId", "does-not-exist")
-	suite.NoError(err)
-	suite.Equal(actual.UserID, "userId")
-	suite.Equal(actual.ExperimentKey, "my_exp")
-	suite.Equal(actual.VariationKey, "does-not-exist")
-	suite.Empty(actual.PrevVariationKey)
-	suite.Equal([]string{"variationKey not found in configuration"}, actual.Messages)
+		key := decision.ExperimentOverrideKey{
+			ExperimentKey: scenario.experimentKey,
+			UserID:        "testUser",
+		}
+
+		actVar, _ := suite.testClient.ForcedVariations.GetVariation(key)
+		suite.Equal(scenario.variationKey, actVar)
+	}
 }
 
 func (suite *ClientTestSuite) TestRemoveForcedVariation() {
@@ -151,24 +148,6 @@ func (suite *ClientTestSuite) TestRemoveForcedVariation() {
 	suite.NoError(err)
 	isEnabled, _ := suite.optlyClient.IsFeatureEnabled("my_feat", suite.userContext)
 	suite.False(isEnabled)
-}
-
-func (suite *ClientTestSuite) TestSetForcedVariationABTestSuccess() {
-	suite.testClient.ProjectConfig.AddMultiVariationABTest("my_exp", "var_1", "var_2")
-	suite.optlyClient.SetForcedVariation("my_exp", "userId", "var_1")
-	variation, err := suite.optlyClient.Activate("my_exp", suite.userContext)
-	suite.NoError(err)
-	suite.Equal("var_1", variation)
-}
-
-func (suite *ClientTestSuite) TestRemoveForcedVariationABTest() {
-	suite.testClient.ProjectConfig.AddMultiVariationABTest("my_exp", "var_1", "var_2")
-	suite.optlyClient.SetForcedVariation("my_exp", "userId", "var_1")
-	_, err := suite.optlyClient.RemoveForcedVariation("my_exp", "userId")
-	suite.NoError(err)
-	variation, err := suite.optlyClient.Activate("my_exp", suite.userContext)
-	suite.NoError(err)
-	suite.Equal("var_2", variation)
 }
 
 func (suite *ClientTestSuite) TestActivateFeature() {

--- a/pkg/optimizely/client_test.go
+++ b/pkg/optimizely/client_test.go
@@ -147,7 +147,7 @@ func (suite *ClientTestSuite) TestRemoveForcedVariation() {
 	suite.testClient.ProjectConfig.AddMultiVariationFeatureTest(feature, "disabled_var", "enabled_var")
 	featureExp := suite.testClient.ProjectConfig.FeatureMap["my_feat"].FeatureExperiments[0]
 	suite.optlyClient.SetForcedVariation(featureExp.Key, "userId", "enabled_var")
-	err := suite.optlyClient.RemoveForcedVariation(featureExp.Key, "userId")
+	_, err := suite.optlyClient.RemoveForcedVariation(featureExp.Key, "userId")
 	suite.NoError(err)
 	isEnabled, _ := suite.optlyClient.IsFeatureEnabled("my_feat", suite.userContext)
 	suite.False(isEnabled)
@@ -164,7 +164,7 @@ func (suite *ClientTestSuite) TestSetForcedVariationABTestSuccess() {
 func (suite *ClientTestSuite) TestRemoveForcedVariationABTest() {
 	suite.testClient.ProjectConfig.AddMultiVariationABTest("my_exp", "var_1", "var_2")
 	suite.optlyClient.SetForcedVariation("my_exp", "userId", "var_1")
-	err := suite.optlyClient.RemoveForcedVariation("my_exp", "userId")
+	_, err := suite.optlyClient.RemoveForcedVariation("my_exp", "userId")
 	suite.NoError(err)
 	variation, err := suite.optlyClient.Activate("my_exp", suite.userContext)
 	suite.NoError(err)

--- a/pkg/optimizely/optimizelytest/client.go
+++ b/pkg/optimizely/optimizelytest/client.go
@@ -79,6 +79,16 @@ func (t *TestClient) GetProcessedEvents() []event.UserEvent {
 	return t.EventProcessor.GetEvents()
 }
 
+// AddExperimentWithVariations is a helper method for adding and experiment with N variations
+func (t TestClient) AddExperimentWithVariations(experimentKey string, variationKeys ...string) {
+	variations := make([]entities.Variation, len(variationKeys))
+	for i, key := range variationKeys {
+		variations[i] = entities.Variation{Key: key}
+	}
+
+	t.AddExperiment(experimentKey, variations)
+}
+
 // AddExperiment is a helper method for creating experiments in the ProjectConfig to facilitate testing.
 func (t *TestClient) AddExperiment(experimentKey string, variations []entities.Variation) {
 	t.ProjectConfig.AddExperiment(experimentKey, variations)

--- a/pkg/optimizely/optimizelytest/config.go
+++ b/pkg/optimizely/optimizelytest/config.go
@@ -207,6 +207,7 @@ func (c *TestProjectConfig) AddFeatureTest(f entities.Feature) *TestProjectConfi
 
 	f.FeatureExperiments = []entities.Experiment{experiment}
 	c.FeatureMap[f.Key] = f
+	c.ExperimentMap[experiment.Key] = experiment
 	return c
 }
 


### PR DESCRIPTION
## Summary
- Introduces a response body to the /override endpoint
- Add additional helper method to optimizelytest pkg

It's been being apparent that Agent should be serving more meaningful context in it's responses than the standard HTTP codes can provide. This PR adds a response body to the /override endpoint to reflect back meaningful sideeffect to the user. 

Note: This is an alternative to https://github.com/optimizely/agent/pull/179 which responds with HTTP error codes.
