### PR TITLE
fix(auth): HMAC secret strings from config are interpreted as base64

### DIFF
--- a/docs/auth.md
+++ b/docs/auth.md
@@ -31,8 +31,8 @@ The configuration properties pertaining to Issuer & Validator mode are listed be
 |Property Name|Environment Variable|Description|
 |---|---|---|
 |ttl|TTL|Time-to-live of access tokens issued|
-|hmacSecrets|HMACSECRETS|Array of secrets used to sign & validate access tokens, using the HMAC SHA256 algorithm. The first value in the array is used to sign issued access tokens. Access tokens signed with any value in the array are considered valid.|
-|clients|N/A|Array of objects, used for token issuance, consisting of `id`, `secretHash`, and `sdkKeys`. Clients provide ID and secret in their requests to `/oauth/token`. Agent validates the request credentials by checking for an exact match of ID, checking that the BCrypt hash of the request secret matches the `secretHash` from configuration, and that the SDK key provided in the `X-Optimizely-Sdk-Key` request header exists in the `sdkKeys` from configuration.|
+|hmacSecrets|HMACSECRETS|Array of secrets used to sign & validate access tokens, using the HMAC SHA256 algorithm. Values must be in base64 format. The first value in the array is used to sign issued access tokens. Access tokens signed with any value in the array are considered valid.|
+|clients|N/A|Array of objects, used for token issuance, consisting of `id`, `secretHash`, and `sdkKeys`. Clients provide ID and secret in their requests to `/oauth/token`. Agent validates the request credentials by checking for an exact match of ID, checking that the BCrypt hash of the request secret matches the `secretHash` from configuration, and that the SDK key provided in the `X-Optimizely-Sdk-Key` request header exists in the `sdkKeys` from configuration. `secretHash` values must be in base64 format.|
 
 To make setup easier, Agent provides a command-line tool that can generate base64-encoded 32-byte random values, and their associated base64-encoded BCrypt hashes:
 ```shell script

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -31,8 +31,8 @@ The configuration properties pertaining to Issuer & Validator mode are listed be
 |Property Name|Environment Variable|Description|
 |---|---|---|
 |ttl|TTL|Time-to-live of access tokens issued|
-|hmacSecrets|HMACSECRETS|Array of secrets used to sign & validate access tokens, using the HMAC SHA256 algorithm. Values must be in base64 format. The first value in the array is used to sign issued access tokens. Access tokens signed with any value in the array are considered valid.|
-|clients|N/A|Array of objects, used for token issuance, consisting of `id`, `secretHash`, and `sdkKeys`. Clients provide ID and secret in their requests to `/oauth/token`. Agent validates the request credentials by checking for an exact match of ID, checking that the BCrypt hash of the request secret matches the `secretHash` from configuration, and that the SDK key provided in the `X-Optimizely-Sdk-Key` request header exists in the `sdkKeys` from configuration. `secretHash` values must be in base64 format.|
+|hmacSecrets|HMACSECRETS|Array of secrets used to sign & validate access tokens, using the HMAC SHA256 algorithm. Values must be base64-format strings. The first value in the array is used to sign issued access tokens. Access tokens signed with any value in the array are considered valid.|
+|clients|N/A|Array of objects, used for token issuance, consisting of `id`, `secretHash`, and `sdkKeys`. Clients provide ID and secret in their requests to `/oauth/token`. Agent validates the request credentials by checking for an exact match of ID, checking that the BCrypt hash of the request secret matches the `secretHash` from configuration, and that the SDK key provided in the `X-Optimizely-Sdk-Key` request header exists in the `sdkKeys` from configuration. `secretHash` values must be base64-format strings.|
 
 To make setup easier, Agent provides a command-line tool that can generate base64-encoded 32-byte random values, and their associated base64-encoded BCrypt hashes:
 ```shell script

--- a/pkg/jwtauth/jwtauth.go
+++ b/pkg/jwtauth/jwtauth.go
@@ -97,7 +97,7 @@ func GenerateClientSecretAndHash() (secretStr, hashStr string, err error) {
 	return secretStr, hashStr, nil
 }
 
-// DecodeSecretHashFromConfig returns the decoded secret hash as a byte slice, or an error if decoding failed
-func DecodeSecretHashFromConfig(configSecretHash string) ([]byte, error) {
+// DecodeConfigValue returns the decoded value from configuration a byte slice, or an error if decoding failed
+func DecodeConfigValue(configSecretHash string) ([]byte, error) {
 	return base64.StdEncoding.DecodeString(configSecretHash)
 }

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -326,7 +326,7 @@ func NewAuth(authConfig *config.ServiceAuthConfig) *Auth {
 		return &Auth{Verifier: NoAuth{}}
 	}
 
-	var decodedSecrets [][]byte
+	decodedSecrets := [][]byte{}
 	for _, hmacSecret := range authConfig.HMACSecrets {
 		decodedSecret, err := jwtauth.DecodeConfigValue(hmacSecret)
 		if err != nil {

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -305,7 +305,7 @@ func (a Auth) AuthorizeAPI(next http.Handler) http.Handler {
 func NewAuth(authConfig *config.ServiceAuthConfig) *Auth {
 
 	if authConfig.JwksURL != "" && len(authConfig.HMACSecrets) != 0 {
-		log.Warn().Msg("HMAC SecretHash will be ignored, JWKS URL will be used for token validation")
+		log.Warn().Msg("HMAC Secrets will be ignored, JWKS URL will be used for token validation")
 	}
 
 	if authConfig.JwksURL != "" {


### PR DESCRIPTION
## Summary

Introduce an expectation that `hmacSecrets` config values are in base64 format. The rationale is that we already have this expectation for client secret hashes in config, and we should be consistent with how we interpret and convert config strings into byte slices.

## Test Plan
Manual testing, updated unit tests, updated example and auth guide
