### PR TITLE
fix: enabled tests to run on remote server

### DIFF
--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -50,7 +50,9 @@ def agent_server():
     Also updates config.yaml file - before agent server starts it sets enableNotifications
     to true and enableOverrides to true and then both back to false at the end
     """
-    if os.getenv('host') == 'http://localhost:8080/':
+    host = os.getenv('host')
+
+    if host == 'http://localhost:8080':
         # start server
         subprocess.Popen(["make", "run"], shell=False)
         wait_for_agent_to_start()

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -50,21 +50,24 @@ def agent_server():
     Also updates config.yaml file - before agent server starts it sets enableNotifications
     to true and enableOverrides to true and then both back to false at the end
     """
-    # start server
-    subprocess.Popen(["make", "run"], shell=False)
-    wait_for_agent_to_start()
+    if os.getenv('host') == 'http://localhost:8080/':
+        # start server
+        subprocess.Popen(["make", "run"], shell=False)
+        wait_for_agent_to_start()
 
-    yield
+        yield
 
-    # Stop server
-    # Kill all 'optimizely' processes
-    # ('optimizely ' are processes associated with Agent server and set in ENV var?
-    # here: https://github.com/optimizely/agent/blob/master/cmd/main.go#L62)
-    # does not remove zombie processes though
-    pid_integers = get_process_id_list('optimizely')
-    for proc in pid_integers:
-        os.kill(proc, signal.SIGKILL)
-        print('\n========  Killing process pid', proc, end='')
+        # Stop server
+        # Kill all 'optimizely' processes
+        # ('optimizely ' are processes associated with Agent server and set in ENV var?
+        # here: https://github.com/optimizely/agent/blob/master/cmd/main.go#L62)
+        # does not remove zombie processes though
+        pid_integers = get_process_id_list('optimizely')
+        for proc in pid_integers:
+            os.kill(proc, signal.SIGKILL)
+            print('\n========  Killing process pid', proc, end='')
+    else:
+        yield 
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
## Summary
@mikecdavis Added a conditional to allow remote host to run tests.
Before it wasn't quite working.
That will help JC with deployed Agent.