### PR TITLE
feat(response): Add more meaningful responses to track and activate

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -44,8 +44,6 @@ paths:
           description: Unauthorized, invalid JWT
         '403':
           $ref: '#/components/responses/Forbidden'
-        '404':
-          description: Event does not exist
       requestBody:
         $ref: '#/components/requestBodies/TrackContext'
   /v1/activate:

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -82,6 +82,7 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 		case "experimentKey-not-found":
 			logger.Debug().Str("experimentKey", key).Msg("experimentKey not found")
 			d = &optimizely.Decision{
+				UserID:        uc.ID,
 				ExperimentKey: key,
 				Error:         "experimentKey not found",
 			}
@@ -89,6 +90,7 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 		case "featureKey-not-found":
 			logger.Debug().Str("featureKey", key).Msg("featureKey not found")
 			d = &optimizely.Decision{
+				UserID:     uc.ID,
 				FeatureKey: key,
 				Error:      "featureKey not found",
 			}

--- a/pkg/handlers/track_test.go
+++ b/pkg/handlers/track_test.go
@@ -133,14 +133,25 @@ func (suite *TrackTestSuite) TestTrackEventNoTags() {
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
 
-	suite.Equal(http.StatusNoContent, rec.Code)
+	suite.Equal(http.StatusOK, rec.Code)
+
+	// Unmarshal response
+	var actual optimizely.Track
+	suite.NoError(json.Unmarshal(rec.Body.Bytes(), &actual))
+
+	expected := optimizely.Track{
+		UserID:   "testUser",
+		EventKey: eventKey,
+	}
+
+	suite.Equal(expected, actual)
 
 	events := suite.tc.GetProcessedEvents()
 	suite.Equal(1, len(events))
 
-	actual := events[0]
-	suite.Equal(eventKey, actual.Conversion.Key)
-	suite.Equal("testUser", actual.VisitorID)
+	actualEvent := events[0]
+	suite.Equal(eventKey, actualEvent.Conversion.Key)
+	suite.Equal("testUser", actualEvent.VisitorID)
 }
 
 func (suite *TrackTestSuite) TestTrackEventWithTags() {
@@ -161,15 +172,26 @@ func (suite *TrackTestSuite) TestTrackEventWithTags() {
 	rec := httptest.NewRecorder()
 	suite.mux.ServeHTTP(rec, req)
 
-	suite.Equal(http.StatusNoContent, rec.Code)
+	suite.Equal(http.StatusOK, rec.Code)
+
+	// Unmarshal response
+	var actual optimizely.Track
+	suite.NoError(json.Unmarshal(rec.Body.Bytes(), &actual))
+
+	expected := optimizely.Track{
+		UserID:   "testUser",
+		EventKey: eventKey,
+	}
+
+	suite.Equal(expected, actual)
 
 	events := suite.tc.GetProcessedEvents()
 	suite.Equal(1, len(events))
 
-	actual := events[0]
-	suite.Equal(eventKey, actual.Conversion.Key)
-	suite.Equal(tb.UserID, actual.VisitorID)
-	suite.Equal(tb.EventTags, actual.Conversion.Tags)
+	actualEvent := events[0]
+	suite.Equal(eventKey, actualEvent.Conversion.Key)
+	suite.Equal(tb.UserID, actualEvent.VisitorID)
+	suite.Equal(tb.EventTags, actualEvent.Conversion.Tags)
 }
 
 func (suite *TrackTestSuite) TestTrackEventWithInvalidTags() {
@@ -190,7 +212,7 @@ func (suite *TrackTestSuite) TestTrackEventParamError() {
 		code    int
 		message string
 	}{
-		{"?eventKey=invalid", http.StatusNotFound, `eventKey: "invalid" not found`},
+		{"?eventKey=invalid", http.StatusOK, "Event with key invalid not found"},
 		{"?eventKey=", http.StatusBadRequest, "missing required path parameter: eventKey"},
 		{"", http.StatusBadRequest, "missing required path parameter: eventKey"},
 	}

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -47,7 +47,7 @@ type Decision struct {
 	Type          string                 `json:"type"`
 	Variables     map[string]interface{} `json:"variables,omitempty"`
 	Enabled       bool                   `json:"enabled"`
-	Error         string                 `json:"error"`
+	Error         string                 `json:"error,omitempty"`
 }
 
 // Override model
@@ -63,7 +63,7 @@ type Override struct {
 type Track struct {
 	UserID   string `json:"userId"`
 	EventKey string `json:"eventKey"`
-	Error    string `json:"error"`
+	Error    string `json:"error,omitempty"`
 }
 
 // UpdateConfig uses config manager to sync and set project config

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -19,7 +19,6 @@ package optimizely
 
 import (
 	"errors"
-	"fmt"
 
 	optimizelyclient "github.com/optimizely/go-sdk/pkg/client"
 	"github.com/optimizely/go-sdk/pkg/decision"
@@ -60,6 +59,13 @@ type Override struct {
 	Messages         []string `json:"messages"`
 }
 
+// Track response model
+type Track struct {
+	UserID   string `json:"userId"`
+	EventKey string `json:"eventKey"`
+	Error    string `json:"error"`
+}
+
 // UpdateConfig uses config manager to sync and set project config
 func (c *OptlyClient) UpdateConfig() {
 	if c.ConfigManager != nil {
@@ -68,17 +74,24 @@ func (c *OptlyClient) UpdateConfig() {
 }
 
 // TrackEvent checks for the existence of the event before calling the OptimizelyClient Track method
-func (c *OptlyClient) TrackEvent(eventKey string, uc entities.UserContext, eventTags map[string]interface{}) error {
-	pc, err := c.ConfigManager.GetConfig()
-	if err != nil {
-		return err
+func (c *OptlyClient) TrackEvent(eventKey string, uc entities.UserContext, eventTags map[string]interface{}) (*Track, error) {
+	tr := &Track{
+		UserID:   uc.ID,
+		EventKey: eventKey,
 	}
 
-	if _, err = pc.GetEventByKey(eventKey); err != nil {
-		return fmt.Errorf("eventKey: %q %w", eventKey, ErrEntityNotFound)
+	if pc, err := c.ConfigManager.GetConfig(); err != nil {
+		return &Track{}, err
+	} else if _, err := pc.GetEventByKey(eventKey); err != nil {
+		tr.Error = err.Error()
+		return tr, nil
 	}
 
-	return c.Track(eventKey, uc, eventTags)
+	if err := c.Track(eventKey, uc, eventTags); err != nil {
+		return &Track{}, err
+	}
+
+	return tr, nil
 }
 
 // SetForcedVariation sets a forced variation for the argument experiment key and user ID

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -41,6 +41,7 @@ type OptlyClient struct {
 
 // Decision Model
 type Decision struct {
+	UserID        string                 `json:"userId"`
 	ExperimentKey string                 `json:"experimentKey"`
 	FeatureKey    string                 `json:"featureKey"`
 	VariationKey  string                 `json:"variationKey"`
@@ -172,6 +173,7 @@ func (c *OptlyClient) ActivateFeature(key string, uc entities.UserContext, disab
 
 	// TODO add experiment and variation keys where applicable
 	dec := &Decision{
+		UserID:     uc.ID,
 		FeatureKey: key,
 		Variables:  variables,
 		Enabled:    enabled,
@@ -196,6 +198,7 @@ func (c *OptlyClient) ActivateExperiment(key string, uc entities.UserContext, di
 	}
 
 	dec := &Decision{
+		UserID:        uc.ID,
 		ExperimentKey: key,
 		VariationKey:  variation,
 		Enabled:       variation != "",

--- a/pkg/optimizely/client_test.go
+++ b/pkg/optimizely/client_test.go
@@ -65,16 +65,23 @@ func (suite *ClientTestSuite) TestTrackEvent() {
 	eventKey := "eventKey"
 	suite.testClient.AddEvent(entities.Event{Key: eventKey})
 	tags := map[string]interface{}{"tag": "value"}
-	_, err := suite.optlyClient.TrackEvent(eventKey, suite.userContext, tags)
+	actual, err := suite.optlyClient.TrackEvent(eventKey, suite.userContext, tags)
 	suite.NoError(err)
+
+	expected := &Track{
+		UserID:   "userId",
+		EventKey: "eventKey",
+	}
+
+	suite.Equal(expected, actual)
 
 	events := suite.testClient.GetProcessedEvents()
 	suite.Equal(1, len(events))
 
-	actual := events[0]
-	suite.Equal(eventKey, actual.Conversion.Key)
-	suite.Equal("userId", actual.VisitorID)
-	suite.Equal(tags, actual.Conversion.Tags)
+	actualEvent := events[0]
+	suite.Equal(eventKey, actualEvent.Conversion.Key)
+	suite.Equal("userId", actualEvent.VisitorID)
+	suite.Equal(tags, actualEvent.Conversion.Tags)
 }
 
 func (suite *ClientTestSuite) TestValidSetForcedVariations() {

--- a/pkg/optimizely/client_test.go
+++ b/pkg/optimizely/client_test.go
@@ -191,6 +191,7 @@ func (suite *ClientTestSuite) TestActivateFeature() {
 	feature := suite.testClient.OptimizelyClient.GetOptimizelyConfig().FeaturesMap["advanced"]
 
 	expected := &Decision{
+		UserID:     "testUser",
 		FeatureKey: "advanced",
 		Type:       "feature",
 		Variables: map[string]interface{}{
@@ -218,6 +219,7 @@ func (suite *ClientTestSuite) TestActivateExperiment() {
 	experiment := suite.testClient.OptimizelyClient.GetOptimizelyConfig().ExperimentsMap["testExperiment1"]
 
 	expected := &Decision{
+		UserID:        "testUser",
 		ExperimentKey: "testExperiment1",
 		VariationKey:  "variationA",
 		Type:          "experiment",

--- a/tests/acceptance/test_acceptance/test_activate.py
+++ b/tests/acceptance/test_acceptance/test_activate.py
@@ -16,8 +16,7 @@ expected_activate_ab = """[
         "featureKey": "",
         "variationKey": "variation_1",
         "type": "experiment",
-        "enabled": true,
-        "error": ""
+        "enabled": true
     }
 ]"""
 
@@ -90,8 +89,7 @@ expected_activate_feat = """[
       "int_var": 1,
       "str_var": "hello"
     },
-    "enabled": true,
-    "error": ""
+    "enabled": true
   }
 ]"""
 
@@ -161,8 +159,7 @@ expected_activate_type_exper = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -170,8 +167,7 @@ expected_activate_type_exper = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   }
 ]"""
 
@@ -182,8 +178,7 @@ expected_activate_type_feat = """[
     "featureKey": "feature_2",
     "variationKey": "",
     "type": "feature",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -191,8 +186,7 @@ expected_activate_type_feat = """[
     "featureKey": "feature_3",
     "variationKey": "",
     "type": "feature",
-    "enabled": false,
-    "error": ""
+    "enabled": false
   },
   {
     "userId": "matjaz",
@@ -200,8 +194,7 @@ expected_activate_type_feat = """[
     "featureKey": "feature_4",
     "variationKey": "",
     "type": "feature",
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -209,8 +202,7 @@ expected_activate_type_feat = """[
     "featureKey": "feature_5",
     "variationKey": "",
     "type": "feature",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -224,8 +216,7 @@ expected_activate_type_feat = """[
       "int_var": 1,
       "str_var": "hello"
     },
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   }
 ]"""
 
@@ -337,8 +328,7 @@ expected_enabled_true_all_true = """[
       "int_var": 1,
       "str_var": "hello"
     },
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -346,8 +336,7 @@ expected_enabled_true_all_true = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   }
 ]"""
 
@@ -358,8 +347,7 @@ expected_enabled_true_feature_off = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   }
 ]"""
 
@@ -372,8 +360,7 @@ expected_enabled_false_feature_off = """[
     "featureKey": "feature_3",
     "variationKey": "",
     "type": "feature",
-    "enabled": false,
-    "error": ""    
+    "enabled": false
   }
 ]"""
 
@@ -384,8 +371,7 @@ expected_enabled_empty = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -399,8 +385,7 @@ expected_enabled_empty = """[
       "int_var": 1,
       "str_var": "hello"
     },
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   }
 ]"""
 
@@ -411,8 +396,7 @@ expected_enabled_invalid = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""    
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -426,8 +410,7 @@ expected_enabled_invalid = """[
       "int_var": 1,
       "str_var": "hello"
     },
-    "enabled": true,
-    "error": ""
+    "enabled": true
   }
 ]"""
 
@@ -484,8 +467,7 @@ expected_activate_with_config = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -493,8 +475,7 @@ expected_activate_with_config = """[
     "featureKey": "",
     "variationKey": "variation_1",
     "type": "experiment",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -508,8 +489,7 @@ expected_activate_with_config = """[
       "int_var": 1,
       "str_var": "hello"
     },
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -517,8 +497,7 @@ expected_activate_with_config = """[
     "featureKey": "feature_2",
     "variationKey": "",
     "type": "feature",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -526,8 +505,7 @@ expected_activate_with_config = """[
     "featureKey": "feature_3",
     "variationKey": "",
     "type": "feature",
-    "enabled": false,
-    "error": ""
+    "enabled": false
   },
   {
     "userId": "matjaz",
@@ -535,8 +513,7 @@ expected_activate_with_config = """[
     "featureKey": "feature_4",
     "variationKey": "",
     "type": "feature",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   },
   {
     "userId": "matjaz",
@@ -544,8 +521,7 @@ expected_activate_with_config = """[
     "featureKey": "feature_5",
     "variationKey": "",
     "type": "feature",
-    "enabled": true,
-    "error": ""
+    "enabled": true
   }
 ]"""
 

--- a/tests/acceptance/test_acceptance/test_activate.py
+++ b/tests/acceptance/test_acceptance/test_activate.py
@@ -11,6 +11,7 @@ BASE_URL = os.getenv('host')
 
 expected_activate_ab = """[
     {
+        "userId": "matjaz",
         "experimentKey": "ab_test1",
         "featureKey": "",
         "variationKey": "variation_1",
@@ -22,6 +23,7 @@ expected_activate_ab = """[
 
 expected_activate_ab_empty_experimentKey = """[
     {
+        "userId": "matjaz",
         "experimentKey": "",
         "featureKey": "",
         "variationKey": "",
@@ -33,6 +35,7 @@ expected_activate_ab_empty_experimentKey = """[
 
 expected_activate_ab_invalid_experimentKey = """[
     {
+        "userId": "matjaz",
         "experimentKey": "invalid exper key",
         "featureKey": "",
         "variationKey": "",
@@ -76,6 +79,7 @@ def test_activate__experiment(session_obj, experiment_key, expected_response,
 
 expected_activate_feat = """[
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_1",
     "variationKey": "",
@@ -93,6 +97,7 @@ expected_activate_feat = """[
 
 expected_activate_feat_empty_featureKey = """[
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "",
     "variationKey": "",
@@ -105,6 +110,7 @@ expected_activate_feat_empty_featureKey = """[
 
 expected_activate_feat_invalid_featureKey = """[
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "invalid feat key",
     "variationKey": "",
@@ -150,6 +156,7 @@ def test_activate__feature(session_obj, feature_key, expected_response,
 
 expected_activate_type_exper = """[
   {
+    "userId": "matjaz",
     "experimentKey": "feature_2_test",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -158,6 +165,7 @@ expected_activate_type_exper = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "ab_test1",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -169,6 +177,7 @@ expected_activate_type_exper = """[
 
 expected_activate_type_feat = """[
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_2",
     "variationKey": "",
@@ -177,6 +186,7 @@ expected_activate_type_feat = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_3",
     "variationKey": "",
@@ -185,6 +195,7 @@ expected_activate_type_feat = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_4",
     "variationKey": "",
@@ -193,6 +204,7 @@ expected_activate_type_feat = """[
     "error": ""    
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_5",
     "variationKey": "",
@@ -201,6 +213,7 @@ expected_activate_type_feat = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_1",
     "variationKey": "",
@@ -313,6 +326,7 @@ def test_activate__disable_tracking(session_obj, experiment, disableTracking,
 
 expected_enabled_true_all_true = """[
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_1",
     "variationKey": "",
@@ -327,6 +341,7 @@ expected_enabled_true_all_true = """[
     "error": ""    
   },
   {
+    "userId": "matjaz",
     "experimentKey": "ab_test1",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -338,6 +353,7 @@ expected_enabled_true_all_true = """[
 
 expected_enabled_true_feature_off = """[
   {
+    "userId": "matjaz",
     "experimentKey": "ab_test1",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -351,6 +367,7 @@ expected_enabled_false_feature_on = """[]"""
 
 expected_enabled_false_feature_off = """[
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_3",
     "variationKey": "",
@@ -362,6 +379,7 @@ expected_enabled_false_feature_off = """[
 
 expected_enabled_empty = """[
   {
+    "userId": "matjaz",
     "experimentKey": "ab_test1",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -370,6 +388,7 @@ expected_enabled_empty = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_1",
     "variationKey": "",
@@ -387,6 +406,7 @@ expected_enabled_empty = """[
 
 expected_enabled_invalid = """[
   {
+    "userId": "matjaz",
     "experimentKey": "ab_test1",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -395,6 +415,7 @@ expected_enabled_invalid = """[
     "error": ""    
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_1",
     "variationKey": "",
@@ -458,6 +479,7 @@ def test_activate__enabled(session_obj, enabled, experimentKey, featureKey,
 
 expected_activate_with_config = """[
   {
+    "userId": "matjaz",
     "experimentKey": "ab_test1",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -466,6 +488,7 @@ expected_activate_with_config = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "feature_2_test",
     "featureKey": "",
     "variationKey": "variation_1",
@@ -474,6 +497,7 @@ expected_activate_with_config = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_1",
     "variationKey": "",
@@ -488,6 +512,7 @@ expected_activate_with_config = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_2",
     "variationKey": "",
@@ -496,6 +521,7 @@ expected_activate_with_config = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_3",
     "variationKey": "",
@@ -504,6 +530,7 @@ expected_activate_with_config = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_4",
     "variationKey": "",
@@ -512,6 +539,7 @@ expected_activate_with_config = """[
     "error": ""
   },
   {
+    "userId": "matjaz",
     "experimentKey": "",
     "featureKey": "feature_5",
     "variationKey": "",

--- a/tests/acceptance/test_acceptance/test_overrides.py
+++ b/tests/acceptance/test_acceptance/test_overrides.py
@@ -41,7 +41,7 @@ def test_overrides(session_obj):
     default_variation = activating.json()[0]['variationKey']
     assert activating.status_code == 200, activating.text
     assert default_variation == 'variation_1', activating.text
-    assert activating.json()[0]['error'] == ''
+#     assert activating.json()[0]['error'] == ''
 
     # Override with "variation_2"
     resp_over = override_variation(session_obj, override_with='variation_2')

--- a/tests/acceptance/test_acceptance/test_track.py
+++ b/tests/acceptance/test_acceptance/test_track.py
@@ -11,9 +11,9 @@ BASE_URL = os.getenv('host')
 
 
 @pytest.mark.parametrize("event_key, status_code", [
-    ("myevent", 204),
+    ("myevent", 200),
     ("", 400),
-    ("invalid_event_key", 404)
+    ("invalid_event_key", 200)
 ], ids=["Valid event key", "Empty event key", "Invalid event key"])
 def test_track(session_obj, event_key, status_code):
     """
@@ -38,10 +38,8 @@ def test_track(session_obj, event_key, status_code):
             resp.raise_for_status()
 
     if event_key == "invalid_event_key":
-        with pytest.raises(requests.exceptions.HTTPError):
-            assert resp.status_code == status_code
-            assert resp.text == '{"error":"eventKey: \\"invalid_event_key\\" not found"}\n'
-            resp.raise_for_status()
+        assert resp.status_code == status_code
+        assert resp.text == '{"userId":"matjaz","eventKey":"invalid_event_key","error":"event with key \\"invalid_event_key\\" not found"}\n'
 
 
 def test_track_403(session_override_sdk_key):


### PR DESCRIPTION
## Summary
- Add /track response
- Remove /track 404 in favor of 200 with error body
- Add userId to /activate response
- Update acceptance suite tests