### PR TITLE
docs: Add advanced configuration notes in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ Below is a comprehensive list of available configuration properties.
 |webhook.projects.<*projectId*>.secret|N/A|Webhook secret used to validate webhook requests originating from the respective projectId|
 |webhook.projects.<*projectId*>.skipSignatureCheck|N/A|Boolean to indicate whether the signature should be validated. TODO remove in favor of empty secret.|
 
+More information about configuring Agent can be found in the [Advanced Configuration Notes](./docs/advanced-configuration.md).
+
 ## API
 
 The core API is implemented as a REST service configured on it's own HTTP listener port (default 8080).

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -1,0 +1,37 @@
+# Advanced Configuration Notes
+
+## Setting Configuration Values
+
+Configuration can be provided to Agent via the following methods:
+1. Reading from environment variables
+2. Reading from a YAML configuration file
+
+When a configuration option is specified through both methods, environment variables take precedence over the config file.
+
+Internally, Optimizely Agent uses the [Viper](https://github.com/spf13/viper) library's support for configuration files and environment variables.
+
+## Config File Location
+
+The default location of the config file is `config.yaml` in the root directory. If you want to specify another location, use the `OPTIMIZELY_CONFIG_FILENAME` environment variable:
+```bash
+OPTIMIZELY_CONFIG_FILENAME=/path/to/other_config_file.yaml make run
+```
+
+## Nested Configuration Options
+When setting the value of "nested" configuration options using environment variables, underscores denote deeper access. The following examples are equivalent ways of setting the client polling interval:
+```yaml
+# Setting a nested value in a .yaml file:
+client:
+    pollingInterval: 120s
+```
+
+```shell script
+// Set environment variable for pollingInterval, nested inside client
+export OPTIMIZELY_CLIENT_POLLINGINTERVAL=120s
+```
+
+##Unsupported Environment Variable Options
+Some options can only be set via config file, and not environment variable (for details on these options, see the Configuration Options table in the [main README](../README.md)):
+- `admin.auth.clients`
+- `api.auth.clients`
+- Options under`webhook.projects`

--- a/docs/advanced-configuration.md
+++ b/docs/advanced-configuration.md
@@ -30,7 +30,7 @@ client:
 export OPTIMIZELY_CLIENT_POLLINGINTERVAL=120s
 ```
 
-##Unsupported Environment Variable Options
+## Unsupported Environment Variable Options
 Some options can only be set via config file, and not environment variable (for details on these options, see the Configuration Options table in the [main README](../README.md)):
 - `admin.auth.clients`
 - `api.auth.clients`


### PR DESCRIPTION
## Summary

Add advanced configuration notes in the docs directory. Mentions config option precedence, Viper, the syntax for setting environment variables for nested config options, and options that can't be set via environment variable

## Issues
https://optimizely.atlassian.net/browse/OASIS-6095
