### PR TITLE
ci(travis): include statik dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -105,10 +105,8 @@ jobs:
       env: APP_VERSION=${TRAVIS_TAG#v}
 
       script:
-        # now we're going to create packages
-        - $TRAVIS_BUILD_DIR/scripts/ci_create_packages.sh
-        # upload packages to artifactory
-        - $TRAVIS_BUILD_DIR/scripts/ci_upload_packages.sh
+        # now we're going to create packages & upload packages
+        - $TRAVIS_BUILD_DIR/scripts/ci_create_packages.sh && $TRAVIS_BUILD_DIR/scripts/ci_upload_packages.sh
 
 before_script:
   # https://github.com/travis-ci/gimme

--- a/.travis.yml
+++ b/.travis.yml
@@ -93,7 +93,16 @@ jobs:
       script:
         - pytest -vv -rA --diff-type=split tests/acceptance/test_acceptance/ --host http://localhost:8080
 
-    - stage: Build
+    - stage: Test Build using latest tag (no upload)
+      name: linux
+      os: linux
+      dist: xenial
+
+      script:
+        - export APP_VERSION=$(git describe --abbrev=0 --tags | tr -d '^v')
+        - $TRAVIS_BUILD_DIR/scripts/ci_create_packages.sh
+
+    - stage: Build and Upload
       if: type = push AND tag IS present
       name: linux
       os: linux

--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -4,6 +4,7 @@ FROM golang:$GO_VERSION-alpine3.10 as builder
 RUN apk add --no-cache make gcc libc-dev git
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
+RUN make install
 RUN make build
 
 FROM alpine:3.10

--- a/scripts/dockerfiles/Dockerfile.static
+++ b/scripts/dockerfiles/Dockerfile.static
@@ -3,6 +3,7 @@ FROM golang:$GO_VERSION as builder
 
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
+RUN make install
 RUN make ci_build_static_binary
 
 FROM scratch


### PR DESCRIPTION
## Summary
- due to new statik depedency, added extra line to run `make install` to the build Dockerfiles
- made uploading packages contingent on successful package creation (previously it was uploading regardless)
