### PR TITLE
fix(activate): Reject empty userId with a 400

### DIFF
--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -18,6 +18,7 @@
 package handlers
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
@@ -174,11 +175,18 @@ func filterDecisions(r *http.Request, decisions []*optimizely.Decision) []*optim
 	return filtered
 }
 
+// ErrEmptyUserID is a constant error if userId is omitted from the request
+var ErrEmptyUserID = errors.New(`missing "userId" in request payload`)
+
 func getUserContext(r *http.Request) (entities.UserContext, error) {
 	var body ActivateBody
 	err := ParseRequestBody(r, &body)
 	if err != nil {
 		return entities.UserContext{}, err
+	}
+
+	if body.UserID == "" {
+		return entities.UserContext{}, ErrEmptyUserID
 	}
 
 	return entities.UserContext{ID: body.UserID, Attributes: body.UserAttributes}, nil


### PR DESCRIPTION
## Summary
- Empty userIds should reject the request

Prior to this change, empty userIds would still yield a valid decision which might have masked a request error. If this becomes an sticking point with customers we will introduce a "generateUserId" config option that will allow users to control this behavior. https://optimizely.atlassian.net/browse/OASIS-6132