### PR TITLE
chore(changelog): Prepare CHANGELOG for 1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [1.0.0] - March 25th 2020
 - Update documentation and examples
 - Add response body for override and track
-- Add user id in activate response
+- Add userId in /activate response
+- Require userId in /activate request
 - Add python integration test suite
 - Add route handler and serve /openapi.yaml
+- Improve logging from the SDK
 
 ## [0.14.0] - March 12th, 2020
 - Update windows build script

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.0] - March 25th 2020
+- Update documentation and examples
+- Add response body for override and track
+- Add user id in activate response
+- Add python integration test suite
+- Add route handler and serve /openapi.yaml
+
 ## [0.14.0] - March 12th, 2020
 - Update windows build script
 - Remove pre-v1 api references

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [1.0.0] - March 25th 2020
+## [1.0.0] - March 26th, 2020
 - Update documentation and examples
 - Add response body for override and track
 - Add userId in /activate response


### PR DESCRIPTION
## [1.0.0] - March 26th, 2020
- Update documentation and examples
- Add response body for override and track
- Add userId in /activate response
- Require userId in /activate request
- Add python integration test suite
- Add route handler and serve /openapi.yaml
- Improve logging from the SDK
