### PR TITLE
docs: Secret generation tool can be used for hmacSecrets

### DIFF
--- a/cmd/generate_secret/main.go
+++ b/cmd/generate_secret/main.go
@@ -30,7 +30,7 @@ func main() {
 	if err != nil {
 		fmt.Printf("error: %v\n", err)
 	} else {
-		fmt.Printf("Client Secret: %v\n", secretStr)
-		fmt.Printf("Client Secret's hash: %v\n", hashStr)
+		fmt.Printf("Secret: %v\n", secretStr)
+		fmt.Printf("Secret's hash: %v\n", hashStr)
 	}
 }

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -38,8 +38,8 @@ To make setup easier, Agent provides a command-line tool that can generate base6
 ```shell script
 // From the Agent root directory
 > make generate_secret
-Client Secret: i3SrdrCy/wEGqggv9OI4FgIsdHHNpOacrmIMJ6SFIkE=
-Client Secret's hash: JDJhJDEyJERGNzhjRXVTNTdOQUZ3cndxTkZ6Li5XQURlazU2R21YeFZjb1pWSkN5eGZ1SXM4VXRLb0ZD
+Secret: i3SrdrCy/wEGqggv9OI4FgIsdHHNpOacrmIMJ6SFIkE=
+Secret's hash: JDJhJDEyJERGNzhjRXVTNTdOQUZ3cndxTkZ6Li5XQURlazU2R21YeFZjb1pWSkN5eGZ1SXM4VXRLb0ZD
 ```
 
 Use the hash value to configure Agent, and pass the secret value as `client_secret` when making access token requests to `/oauth/token`. For details of the access token issuance endpoint, see the OpenAPI spec file.

--- a/docs/auth.md
+++ b/docs/auth.md
@@ -34,6 +34,8 @@ The configuration properties pertaining to Issuer & Validator mode are listed be
 |hmacSecrets|HMACSECRETS|Array of secrets used to sign & validate access tokens, using the HMAC SHA256 algorithm. Values must be base64-format strings. The first value in the array is used to sign issued access tokens. Access tokens signed with any value in the array are considered valid.|
 |clients|N/A|Array of objects, used for token issuance, consisting of `id`, `secretHash`, and `sdkKeys`. Clients provide ID and secret in their requests to `/oauth/token`. Agent validates the request credentials by checking for an exact match of ID, checking that the BCrypt hash of the request secret matches the `secretHash` from configuration, and that the SDK key provided in the `X-Optimizely-Sdk-Key` request header exists in the `sdkKeys` from configuration. `secretHash` values must be base64-format strings.|
 
+#### generate_secret tool
+
 To make setup easier, Agent provides a command-line tool that can generate base64-encoded 32-byte random values, and their associated base64-encoded BCrypt hashes:
 ```shell script
 // From the Agent root directory
@@ -42,7 +44,10 @@ Secret: i3SrdrCy/wEGqggv9OI4FgIsdHHNpOacrmIMJ6SFIkE=
 Secret's hash: JDJhJDEyJERGNzhjRXVTNTdOQUZ3cndxTkZ6Li5XQURlazU2R21YeFZjb1pWSkN5eGZ1SXM4VXRLb0ZD
 ```
 
-Use the hash value to configure Agent, and pass the secret value as `client_secret` when making access token requests to `/oauth/token`. For details of the access token issuance endpoint, see the OpenAPI spec file.
+The generate_secret tool can be used for two purposes:
+- These secrets can be used to set the `hmacSecrets` configuration value.
+- These secrets can be used for authenticating access token requests to `/oauth/token`. Set the hash value as the `secretHash` configuration property (inside `clients`). Then, when making access token requests to `/oauth/token`, pass the secret value as `client_secret` in the request. For details of the access token issuance endpoint, see the [OpenAPI spec file](../api/openapi-spec/openapi.yaml) and the [auth example](../examples/auth.py).
+
 
 ### Validator-only
 The configuration properties pertaining to Validator-only mode are listed below:

--- a/examples/auth.py
+++ b/examples/auth.py
@@ -12,9 +12,9 @@ import sys
 # You can use the generate_secret tool included with Agent to generate this:
 
 # > make generate_secret
-# Client Secret: CvzvkWm3V1D9RBxPWEjC+ud9zvwcOvnnLkWaIkzDGyA=
+# Secret: CvzvkWm3V1D9RBxPWEjC+ud9zvwcOvnnLkWaIkzDGyA=
 
-# You can ignore the second line that says "Client Secret's hash".
+# You can ignore the second line that says "Secret's hash".
 
 # Then, set an environment variable to make this secret available to Agent:
 # > export OPTIMIZELY_API_AUTH_HMACSECRETS=CvzvkWm3V1D9RBxPWEjC+ud9zvwcOvnnLkWaIkzDGyA=
@@ -23,8 +23,8 @@ import sys
 # Again, you can use the generate_secret tool included with Agent to generate these:
 #
 # > make generate_secret
-# Client Secret: 0bfLVX9U3Lpr6Qe4X3DSSIWNqEkEQ4bkX1WZ5Km6spM=
-# Client Secret's hash: JDJhJDEyJEdkSHpicHpRODBqOC9FQzRneGIyNXU0ZFVPMFNKcUhkdTRUQXRzWUJOdjRzRmcuVGdFUTUu
+# Secret: 0bfLVX9U3Lpr6Qe4X3DSSIWNqEkEQ4bkX1WZ5Km6spM=
+# Secret's hash: JDJhJDEyJEdkSHpicHpRODBqOC9FQzRneGIyNXU0ZFVPMFNKcUhkdTRUQXRzWUJOdjRzRmcuVGdFUTUu
 #
 # Take the hash, and add it to your agent configuration file (default: config.yaml) under the "api" section,
 # along with your desired client ID and SDK key:


### PR DESCRIPTION
## Summary
Update documentation and secret generation tool output to make it clearer that the values generated can be used for the `hmacSecrets` config option (in addition to the client secret & secret hash configuration options).