### PR TITLE
fix: need curl to download golangci/golangci-lint

### DIFF
--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -1,7 +1,7 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION-alpine3.10 as builder
 # hadolint ignore=DL3018
-RUN apk add --no-cache make gcc libc-dev git
+RUN apk add --no-cache make gcc libc-dev git curl
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
 RUN make setup build


### PR DESCRIPTION
## Summary
the depdency golangci/golangci-lint requires curl to download
we must provide curl in the base image when compiling agent

