### PR TITLE
ci(travis): update ca-certificate in docker alpine

### DIFF
--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -7,6 +7,6 @@ COPY . .
 RUN make setup build
 
 FROM alpine:3.10
-RUN apk add --no-cache ca-certificates=20190108-r0
+RUN apk add --no-cache ca-certificates=20191127-r0
 COPY --from=builder /go/src/github.com/optimizely/agent/bin/optimizely /optimizely
 CMD ["/optimizely"]


### PR DESCRIPTION
## Summary
update ca-certificate for alpine image since old one is no longer available
