### PR TITLE
fix: update to go-sdk 1.1.3.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - April 22, 2020
+- Update to use go-sdk 1.1.3. This has a fix to the batch event processor was creating a dispatcher without a logger.
+
 ## [1.0.0] - March 26th, 2020
 - Update documentation and examples
 - Add response body for override and track

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
 	github.com/lestrrat-go/jwx v0.9.0
-	github.com/optimizely/go-sdk v1.1.2
+	github.com/optimizely/go-sdk v1.1.3
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/zerolog v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -85,6 +85,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/optimizely/go-sdk v1.1.2 h1:rojFANR6mp/eKfC/+HnXZNs+H0tpaS8qrQExBd/LptE=
 github.com/optimizely/go-sdk v1.1.2/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
+github.com/optimizely/go-sdk v1.1.3 h1:zvhrj+nNlCrndXe7DbFtTQiy9Rny6ZLMyqdap1TMFi8=
+github.com/optimizely/go-sdk v1.1.3/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=


### PR DESCRIPTION
## Summary
- This fixes an error where the batch event processor was creating a http dispatcher without a logger.  This in turn caused a crash.
