### PR TITLE
ci(travis): awscliv2 changed binary location

### DIFF
--- a/scripts/upload_artifacts.sh
+++ b/scripts/upload_artifacts.sh
@@ -2,5 +2,5 @@
 set -e
 
 choco install awscli
-export PATH=$PATH:'/c/Program Files/Amazon/AWSCLI/bin'
+export PATH=$PATH:'/c/Program Files/Amazon/AWSCLIV2'
 aws s3 cp "bin\optimizely.exe" "s3://${AWS_BUCKET}/${TRAVIS_REPO_SLUG}/${TRAVIS_BUILD_NUMBER}/${TRAVIS_JOB_NUMBER}/optimizely.exe" --quiet


### PR DESCRIPTION
## Summary
`choco install awscli` previously installed it in `/c/Program Files/Amazon/AWSCLI/bin`
now the same command installs `AWSCLIV2` which drops the aws.exe into `/c/Program Files/Amazon/AWSCLIV2` instead. Only figured this out by doing `ls` in each installed directory. Even these logs didn't help too much: (click detals) https://chocolatey.org/packages/awscli#testingResults