### PR TITLE
docs(openapi): Fix documented response code

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -36,8 +36,8 @@ paths:
       operationId: trackEvent
       description: Send event and user details to Optimizely analytics backend, so you can see metrics for an experiment. You can view metrics either on your Results page or as a data export.
       responses:
-        '204':
-          description: No content, event received
+        '200':
+          description: Valid response, event received
         '400':
           description: Missing required parameters
         '401':


### PR DESCRIPTION
## Summary
The current API spec is out of date with the existing implementation. `/track` returns an HTTP 200 and not a 204. The change was made as part of [this](https://github.com/optimizely/agent/commit/70300ade293bfb25286fb8f619fb656274b8f4bc#diff-792ff1ebb42545c5d3e4b34233906b27L75-R70) commit, but the spec was not updated.

