### PR TITLE
chore: Update Go SDK to v1.2.0, prepare changelog for release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - May 21st, 2020
+- Upgrade to use go-sdk 1.2.0. This adds support for multi-rule rollouts.
+
 ## [1.0.2] - April 26th, 2020
 - Add datafileURLTemplate configuration option
 

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,6 @@ require (
 	github.com/go-chi/render v1.0.1
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
-	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/lestrrat-go/jwx v0.9.0
 	github.com/optimizely/go-sdk v1.2.0
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6

--- a/go.mod
+++ b/go.mod
@@ -10,8 +10,9 @@ require (
 	github.com/go-chi/render v1.0.1
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
+	github.com/hashicorp/go-multierror v1.1.0 // indirect
 	github.com/lestrrat-go/jwx v0.9.0
-	github.com/optimizely/go-sdk v1.1.3-0.20200504184941-ac759bfb12f8
+	github.com/optimizely/go-sdk v1.2.0
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/zerolog v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -95,6 +95,8 @@ github.com/optimizely/go-sdk v1.1.3-0.20200504184941-ac759bfb12f8 h1:EO1/LbxE2C4
 github.com/optimizely/go-sdk v1.1.3-0.20200504184941-ac759bfb12f8/go.mod h1:ehZPiEzNzNJw98EFrZX1C9h9gVgVRCiWosQEVlgivCw=
 github.com/optimizely/go-sdk v1.1.3 h1:zvhrj+nNlCrndXe7DbFtTQiy9Rny6ZLMyqdap1TMFi8=
 github.com/optimizely/go-sdk v1.1.3/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
+github.com/optimizely/go-sdk v1.2.0 h1:nx6UJ6ecOql/k5AlRiAAOAocRcNFMrME7OepRW/uHBo=
+github.com/optimizely/go-sdk v1.2.0/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/go.sum
+++ b/go.sum
@@ -55,10 +55,6 @@ github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/ad
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.0/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
-github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
-github.com/hashicorp/go-multierror v1.1.0 h1:B9UzwGQJehnUY1yNrnwREHc3fGbC2xefo8g4TbElacI=
-github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+vmowP0z+KUhOZdA=
 github.com/hashicorp/hcl v1.0.0 h1:0Anlzjpi4vEasTeNFn2mLJgTSwt0+6sfsiTG8qcWGx4=
 github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T20WEQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -89,12 +85,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/optimizely/go-sdk v1.1.2 h1:rojFANR6mp/eKfC/+HnXZNs+H0tpaS8qrQExBd/LptE=
-github.com/optimizely/go-sdk v1.1.2/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
-github.com/optimizely/go-sdk v1.1.3-0.20200504184941-ac759bfb12f8 h1:EO1/LbxE2C40lUfmUyxEZrX++WwHK4AJikB90fmpanE=
-github.com/optimizely/go-sdk v1.1.3-0.20200504184941-ac759bfb12f8/go.mod h1:ehZPiEzNzNJw98EFrZX1C9h9gVgVRCiWosQEVlgivCw=
-github.com/optimizely/go-sdk v1.1.3 h1:zvhrj+nNlCrndXe7DbFtTQiy9Rny6ZLMyqdap1TMFi8=
-github.com/optimizely/go-sdk v1.1.3/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/optimizely/go-sdk v1.2.0 h1:nx6UJ6ecOql/k5AlRiAAOAocRcNFMrME7OepRW/uHBo=
 github.com/optimizely/go-sdk v1.2.0/go.mod h1:aA/UeFjLeQefRlvfTI8QkvBmJWPvLEHamKmp/CdJqGU=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=

--- a/pkg/optimizely/client.go
+++ b/pkg/optimizely/client.go
@@ -170,7 +170,7 @@ func (c *OptlyClient) RemoveForcedVariation(experimentKey, userID string) (*Over
 // ActivateFeature activates a feature for a given user by getting the feature enabled status and all
 // associated variables
 func (c *OptlyClient) ActivateFeature(key string, uc entities.UserContext, disableTracking bool) (*Decision, error) {
-	enabled, variables, err := c.GetAllFeatureVariablesWithDecision(key, uc)
+	enabled, variables, err := c.GetAllFeatureVariables(key, uc)
 	if err != nil {
 		return &Decision{}, err
 	}


### PR DESCRIPTION
## Summary
- Update Go SDK dependency to v1.2.0 (add support for multi-rule rollouts)
- Revert usage of method not available in Go SDK v.1.2.0
- Update CHANGELOG to prepare for v1.1.0 Agent release