### PR TITLE
docs(openapi): Fix typo in config spec.

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -299,11 +299,11 @@ components:
       properties:
         revision:
           type: string
-        experimentMap:
+        experimentsMap:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/Experiment'
-        featureMap:
+        featuresMap:
           type: object
           additionalProperties:
             $ref: '#/components/schemas/Feature'


### PR DESCRIPTION
## Summary
- Fix typo in OptimizelyConfig API spec
