### PR TITLE
feat: run docker container as non root user

### DIFF
--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -1,6 +1,7 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION-alpine3.10 as builder
 # hadolint ignore=DL3018
+RUN addgroup -S 10001 && adduser -S agentuser -G 10001
 RUN apk add --no-cache make gcc libc-dev git curl
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
@@ -9,4 +10,6 @@ RUN make setup build
 FROM alpine:3.10
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/optimizely/agent/bin/optimizely /optimizely
+COPY --from=builder /etc/passwd /etc/passwd
+USER agentuser
 CMD ["/optimizely"]

--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -1,7 +1,7 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION-alpine3.10 as builder
 # hadolint ignore=DL3018
-RUN addgroup -S 10001 && adduser -S agentuser -G 10001
+RUN addgroup -S agentgroup && adduser -S agentuser -G agentgroup
 RUN apk add --no-cache make gcc libc-dev git curl
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .

--- a/scripts/dockerfiles/Dockerfile.static
+++ b/scripts/dockerfiles/Dockerfile.static
@@ -1,8 +1,7 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION as builder
-RUN  addgroup agentgroup
-RUN useradd -u 10001 agentuser -g agentgroup
-
+RUN addgroup -u 1000 agentgroup
+RUN useradd -u 1000 agentuser -g agentgroup
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
 RUN make setup build

--- a/scripts/dockerfiles/Dockerfile.static
+++ b/scripts/dockerfiles/Dockerfile.static
@@ -1,6 +1,7 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION as builder
-RUN useradd -u 10001 agentuser
+RUN  addgroup agentgroup
+RUN useradd -u 10001 agentuser -g agentgroup
 
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .

--- a/scripts/dockerfiles/Dockerfile.static
+++ b/scripts/dockerfiles/Dockerfile.static
@@ -1,5 +1,6 @@
 ARG GO_VERSION
 FROM golang:$GO_VERSION as builder
+RUN useradd -u 10001 agentuser
 
 WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
@@ -9,5 +10,7 @@ RUN make ci_build_static_binary
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /go/src/github.com/optimizely/agent/bin/optimizely /optimizely
+COPY --from=builder /etc/passwd /etc/passwd
+USER agentuser
 CMD ["/optimizely"]
 


### PR DESCRIPTION
## Summary
- run docker container as non root user
- tested just locally, it needs to be tested while deployed
- travis  handled this new user with no problem:

```
Step 11/13 : COPY --from=builder /etc/passwd /etc/passwd
 ---> e8bb295c9edf
Step 12/13 : USER agentuser
 ---> Running in 1035f68bb9ee
Removing intermediate container 1035f68bb9ee
 ---> 0ebd05595170
Step 13/13 : CMD ["/optimizely"]
 ---> Running in b140d42bd211
Removing intermediate container b140d42bd211
 ---> 2c13863c1264
[Warning] One or more build-args [NUM_RUNS SDK_BRANCH TESTAPP_BRANCH TRAVIS_COM_TOKEN] were not consumed
Successfully built 2c13863c1264
Successfully tagged agent-testapp:latest
```

## Issues
- https://optimizely.atlassian.net/browse/OASIS-6579
