### PR TITLE
feat: Log warnings when HTTPS and authorization are not enabled via configuration

### DIFF
--- a/cmd/optimizely/main.go
+++ b/cmd/optimizely/main.go
@@ -99,7 +99,7 @@ func main() {
 	conf := loadConfig(v)
 	initLogging(conf.Log)
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	agentMetricsRegistry := metrics.NewRegistry()
 	sdkMetricsRegistry := optimizely.NewRegistry(agentMetricsRegistry)

--- a/cmd/optimizely/main.go
+++ b/cmd/optimizely/main.go
@@ -99,6 +99,8 @@ func main() {
 	conf := loadConfig(v)
 	initLogging(conf.Log)
 
+	conf.LogConfigurationWarnings()
+
 	agentMetricsRegistry := metrics.NewRegistry()
 	sdkMetricsRegistry := optimizely.NewRegistry(agentMetricsRegistry)
 

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,7 @@
 package config
 
 import (
+	"github.com/rs/zerolog/log"
 	"time"
 )
 
@@ -107,6 +108,13 @@ type AgentConfig struct {
 	Webhook WebhookConfig `json:"webhook"`
 }
 
+// LogConfigurationWarnings checks this configuration and logs any relevant warnings.
+func (ac *AgentConfig) LogConfigurationWarnings() {
+	if !ac.Server.isHTTPSConfigurationSet() {
+		log.Warn().Msg("keyfile and cerfile not available, so server will use HTTP. For production deployments, it is recommended to either set keyfile and certfile for HTTPS, or run Agent behind a load balancer/reverse proxy that uses HTTPS.")
+	}
+}
+
 // ClientConfig holds the configuration options for the Optimizely Client.
 type ClientConfig struct {
 	PollingInterval     time.Duration `json:"pollingInterval"`
@@ -131,6 +139,10 @@ type ServerConfig struct {
 	KeyFile         string        `json:"keyFile"`
 	DisabledCiphers []string      `json:"disabledCiphers"`
 	HealthCheckPath string        `json:"healthCheckPath"`
+}
+
+func (sc *ServerConfig) isHTTPSConfigurationSet() bool {
+	return sc.KeyFile != "" && sc.CertFile != ""
 }
 
 // APIConfig holds the REST API configuration

--- a/config/config.go
+++ b/config/config.go
@@ -115,8 +115,8 @@ var HTTPSDisabledWarning = "keyfile and cerfile not available, so server will us
 // AuthDisabledWarningTemplate is used to log a warning when auth is disabled for API or Admin endpoints
 var AuthDisabledWarningTemplate = "Authorization not enabled for %v endpoint. For production deployments, authorization is recommended."
 
-// LogConfigurationWarnings checks this configuration and logs any relevant warnings.
-func (ac *AgentConfig) LogConfigurationWarnings() {
+// LogConfigWarnings checks this configuration and logs any relevant warnings.
+func (ac *AgentConfig) LogConfigWarnings() {
 	if !ac.Server.isHTTPSEnabled() {
 		log.Warn().Msg(HTTPSDisabledWarning)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -110,10 +110,10 @@ type AgentConfig struct {
 }
 
 // HTTPSDisabledWarning is logged when keyfile and certifle are not provided in server configuration
-var HTTPSDisabledWarning string = "keyfile and cerfile not available, so server will use HTTP. For production deployments, it is recommended to either set keyfile and certfile for HTTPS, or run Agent behind a load balancer/reverse proxy that uses HTTPS."
+var HTTPSDisabledWarning = "keyfile and cerfile not available, so server will use HTTP. For production deployments, it is recommended to either set keyfile and certfile for HTTPS, or run Agent behind a load balancer/reverse proxy that uses HTTPS."
 
 // AuthDisabledWarningTemplate is used to log a warning when auth is disabled for API or Admin endpoints
-var AuthDisabledWarningTemplate string = "Authorization not enabled for %v endpoint. For production deployments, authorization is recommended."
+var AuthDisabledWarningTemplate = "Authorization not enabled for %v endpoint. For production deployments, authorization is recommended."
 
 // LogConfigurationWarnings checks this configuration and logs any relevant warnings.
 func (ac *AgentConfig) LogConfigurationWarnings() {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -18,13 +18,13 @@ package config
 
 import (
 	"fmt"
-	"github.com/rs/zerolog"
-	"github.com/rs/zerolog/log"
-	"github.com/stretchr/testify/suite"
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 func TestDefaultConfig(t *testing.T) {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -106,10 +106,10 @@ type LogConfigurationWarningsTestSuite struct {
 }
 
 func (s *LogConfigurationWarningsTestSuite) SetupTest() {
-	testHook := &testLogHook{}
+	s.hook = &testLogHook{}
 	// Replace global logger for this test suite
 	s.globalLogger = log.Logger
-	log.Logger = log.Hook(testHook)
+	log.Logger = log.Hook(s.hook)
 }
 
 func (s *LogConfigurationWarningsTestSuite) TearDownTest() {
@@ -122,11 +122,9 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHTTPSNot
 	conf.Server.KeyFile = ""
 	conf.Server.CertFile = ""
 
-	testHook := &testLogHook{}
-	log.Logger = log.Hook(testHook)
-
 	conf.LogConfigurationWarnings()
-	s.Contains(testHook.logs, &logObservation{
+
+	s.Contains(s.hook.logs, &logObservation{
 		msg:   HTTPSDisabledWarning,
 		level: zerolog.WarnLevel,
 	})
@@ -137,11 +135,9 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHTTPSSet
 	conf.Server.KeyFile = "/path/to/keyfile"
 	conf.Server.CertFile = "/path/to/certfile"
 
-	testHook := &testLogHook{}
-	log.Logger = log.Hook(testHook)
-
 	conf.LogConfigurationWarnings()
-	s.NotContains(testHook.messages(), HTTPSDisabledWarning)
+
+	s.NotContains(s.hook.messages(), HTTPSDisabledWarning)
 }
 
 func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthNotSet() {
@@ -149,16 +145,13 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthNotS
 	conf.API.Auth.JwksURL = ""
 	conf.API.Auth.HMACSecrets = []string{}
 
-	testHook := &testLogHook{}
-	log.Logger = log.Hook(testHook)
-
 	conf.LogConfigurationWarnings()
 
-	s.Contains(testHook.logs, &logObservation{
+	s.Contains(s.hook.logs, &logObservation{
 		msg:   fmt.Sprintf(AuthDisabledWarningTemplate, "API"),
 		level: zerolog.WarnLevel,
 	})
-	s.Contains(testHook.logs, &logObservation{
+	s.Contains(s.hook.logs, &logObservation{
 		msg:   fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"),
 		level: zerolog.WarnLevel,
 	})
@@ -168,13 +161,10 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsJWKSUrlS
 	conf := NewDefaultConfig()
 	conf.API.Auth.JwksURL = "https://YOUR_DOMAIN/.well-known/jwks.json"
 
-	testHook := &testLogHook{}
-	log.Logger = log.Hook(testHook)
-
 	conf.LogConfigurationWarnings()
 
-	s.NotContains(testHook.messages(), fmt.Sprintf(AuthDisabledWarningTemplate, "API"))
-	s.Contains(testHook.logs, &logObservation{
+	s.NotContains(s.hook.messages(), fmt.Sprintf(AuthDisabledWarningTemplate, "API"))
+	s.Contains(s.hook.logs, &logObservation{
 		msg:   fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"),
 		level: zerolog.WarnLevel,
 	})
@@ -183,16 +173,13 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHMACSecr
 	conf := NewDefaultConfig()
 	conf.Admin.Auth.HMACSecrets = []string{"abcd123"}
 
-	testHook := &testLogHook{}
-	log.Logger = log.Hook(testHook)
-
 	conf.LogConfigurationWarnings()
 
-	s.Contains(testHook.logs, &logObservation{
+	s.Contains(s.hook.logs, &logObservation{
 		msg:   fmt.Sprintf(AuthDisabledWarningTemplate, "API"),
 		level: zerolog.WarnLevel,
 	})
-	s.NotContains(testHook.messages(), fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"))
+	s.NotContains(s.hook.messages(), fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"))
 }
 
 func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthSetForBoth() {
@@ -200,12 +187,9 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthSetF
 	conf.API.Auth.HMACSecrets = []string{"abcd123"}
 	conf.Admin.Auth.HMACSecrets = []string{"abcd123"}
 
-	testHook := &testLogHook{}
-	log.Logger = log.Hook(testHook)
-
 	conf.LogConfigurationWarnings()
 
-	messages := testHook.messages()
+	messages := s.hook.messages()
 	s.NotContains(messages, fmt.Sprintf(AuthDisabledWarningTemplate, "API"))
 	s.NotContains(messages, fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"))
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,30 +99,30 @@ func (th *testLogHook) messages() []string {
 	return logMessages
 }
 
-type LogConfigurationWarningsTestSuite struct {
+type LogConfigWarningsTestSuite struct {
 	suite.Suite
 	hook         *testLogHook
 	globalLogger zerolog.Logger
 }
 
-func (s *LogConfigurationWarningsTestSuite) SetupTest() {
+func (s *LogConfigWarningsTestSuite) SetupTest() {
 	s.hook = &testLogHook{}
 	// Replace global logger for this test suite
 	s.globalLogger = log.Logger
 	log.Logger = log.Hook(s.hook)
 }
 
-func (s *LogConfigurationWarningsTestSuite) TearDownTest() {
+func (s *LogConfigWarningsTestSuite) TearDownTest() {
 	// Restore global logger to original state
 	log.Logger = s.globalLogger
 }
 
-func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHTTPSNotSet() {
+func (s *LogConfigWarningsTestSuite) TestLogConfigWarningsHTTPSNotSet() {
 	conf := NewDefaultConfig()
 	conf.Server.KeyFile = ""
 	conf.Server.CertFile = ""
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	s.Contains(s.hook.logs, &logObservation{
 		msg:   HTTPSDisabledWarning,
@@ -130,22 +130,22 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHTTPSNot
 	})
 }
 
-func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHTTPSSet() {
+func (s *LogConfigWarningsTestSuite) TestLogConfigWarningsHTTPSSet() {
 	conf := NewDefaultConfig()
 	conf.Server.KeyFile = "/path/to/keyfile"
 	conf.Server.CertFile = "/path/to/certfile"
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	s.NotContains(s.hook.messages(), HTTPSDisabledWarning)
 }
 
-func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthNotSet() {
+func (s *LogConfigWarningsTestSuite) TestLogConfigWarningsAuthNotSet() {
 	conf := NewDefaultConfig()
 	conf.API.Auth.JwksURL = ""
 	conf.API.Auth.HMACSecrets = []string{}
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	s.Contains(s.hook.logs, &logObservation{
 		msg:   fmt.Sprintf(AuthDisabledWarningTemplate, "API"),
@@ -157,11 +157,11 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthNotS
 	})
 }
 
-func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsJWKSUrlSetForAPI() {
+func (s *LogConfigWarningsTestSuite) TestLogConfigWarningsJWKSUrlSetForAPI() {
 	conf := NewDefaultConfig()
 	conf.API.Auth.JwksURL = "https://YOUR_DOMAIN/.well-known/jwks.json"
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	s.NotContains(s.hook.messages(), fmt.Sprintf(AuthDisabledWarningTemplate, "API"))
 	s.Contains(s.hook.logs, &logObservation{
@@ -169,11 +169,12 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsJWKSUrlS
 		level: zerolog.WarnLevel,
 	})
 }
-func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHMACSecretsSetForAdmin() {
+
+func (s *LogConfigWarningsTestSuite) TestLogConfigWarningsHMACSecretsSetForAdmin() {
 	conf := NewDefaultConfig()
 	conf.Admin.Auth.HMACSecrets = []string{"abcd123"}
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	s.Contains(s.hook.logs, &logObservation{
 		msg:   fmt.Sprintf(AuthDisabledWarningTemplate, "API"),
@@ -182,18 +183,18 @@ func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsHMACSecr
 	s.NotContains(s.hook.messages(), fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"))
 }
 
-func (s *LogConfigurationWarningsTestSuite) TestLogConfigurationWarningsAuthSetForBoth() {
+func (s *LogConfigWarningsTestSuite) TestLogConfigWarningsAuthSetForBoth() {
 	conf := NewDefaultConfig()
 	conf.API.Auth.HMACSecrets = []string{"abcd123"}
 	conf.Admin.Auth.HMACSecrets = []string{"abcd123"}
 
-	conf.LogConfigurationWarnings()
+	conf.LogConfigWarnings()
 
 	messages := s.hook.messages()
 	s.NotContains(messages, fmt.Sprintf(AuthDisabledWarningTemplate, "API"))
 	s.NotContains(messages, fmt.Sprintf(AuthDisabledWarningTemplate, "Admin"))
 }
 
-func TestLogConfigurationWarnings(t *testing.T) {
-	suite.Run(t, new(LogConfigurationWarningsTestSuite))
+func TestLogConfigWarnings(t *testing.T) {
+	suite.Run(t, new(LogConfigWarningsTestSuite))
 }


### PR DESCRIPTION
## Summary

With this change, on startup, when HTTPS or authorization for admin/API endpoints are not set via configuration, warning messages are logged. The messages recommend enabling HTTPS and authorization for production deployments.


## Issues
OASIS-6585
