### PR TITLE
chore(release): Update CHANGELOG for 1.3.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [1.3.0] - July 7th, 2020
+- Upgrade to use go-sdk v1.3.0. This adds support for JSON feature variables
+- Add /debug/pprof endpoints to the admin service
+- Run docker container as non root user
+- Log warnings when HTTPS and authorization are not enabled via configuration
+
 ## [1.2.0] - June 18th, 2020
 - Expose event dispatch URL as a config parameter
 - Return experimentKey and variationKey with feature test decisions


### PR DESCRIPTION
## [1.3.0] - July 7th, 2020
- Upgrade to use go-sdk v1.3.0. This adds support for JSON feature variables
- Add /debug/pprof endpoints to the admin service
- Run docker container as non root user
- Log warnings when HTTPS and authorization are not enabled via configuration