### PR TITLE
feat(security): add SDK key validation configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Below is a comprehensive list of available configuration properties.
 |client.queueSize|OPTIMIZELY_CLIENT_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
 |client.datafileURLTemplate|OPTIMIZELY_CLIENT_DATAFILEURLTEMPLATE|Template URL for SDK datafile location. Default: https://cdn.optimizely.com/datafiles/%s.json|
 |client.eventURL|OPTIMIZELY_CLIENT_EVENTURL|URL for dispatching events. Default: https://logx.optimizely.com/v1/events|
-|client.sdkKeyRegex|OPTIMIZELY_CLIENT_SDKKEYREGEX|Regex to validate SDK keys provided in request header. Default: ^[[:alnum:]]+$|
+|client.sdkKeyRegex|OPTIMIZELY_CLIENT_SDKKEYREGEX|Regex to validate SDK keys provided in request header. Default: ^\\w+$|
 |config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
 |keyfile|OPTIMIZELY_KEYFILE|Path to a key file, used to run Agent with HTTPS|
 |log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Below is a comprehensive list of available configuration properties.
 |client.queueSize|OPTIMIZELY_CLIENT_QUEUESIZE|The max number of events pending dispatch. Default: 1000|
 |client.datafileURLTemplate|OPTIMIZELY_CLIENT_DATAFILEURLTEMPLATE|Template URL for SDK datafile location. Default: https://cdn.optimizely.com/datafiles/%s.json|
 |client.eventURL|OPTIMIZELY_CLIENT_EVENTURL|URL for dispatching events. Default: https://logx.optimizely.com/v1/events|
+|client.sdkKeyRegex|OPTIMIZELY_CLIENT_SDKKEYREGEX|Regex to validate SDK keys provided in request header. Default: ^[[:alnum:]]+$|
 |config.filename|OPTIMIZELY_CONFIG_FILENAME|Location of the configuration YAML file. Default: ./config.yaml|
 |keyfile|OPTIMIZELY_KEYFILE|Path to a key file, used to run Agent with HTTPS|
 |log.level|OPTIMIZELY_LOG_LEVEL|The log [level](https://github.com/rs/zerolog#leveled-logging) for the agent. Default: info|

--- a/cmd/optimizely/main_test.go
+++ b/cmd/optimizely/main_test.go
@@ -55,6 +55,7 @@ func assertClient(t *testing.T, actual config.ClientConfig) {
 	assert.Equal(t, 1*time.Minute, actual.FlushInterval)
 	assert.Equal(t, "https://localhost/v1/%s.json", actual.DatafileURLTemplate)
 	assert.Equal(t, "https://logx.localhost.com/v1", actual.EventURL)
+	assert.Equal(t, "custom-regex", actual.SdkKeyRegex)
 }
 
 func assertLog(t *testing.T, actual config.LogConfig) {
@@ -163,6 +164,7 @@ func TestViperProps(t *testing.T) {
 	v.Set("client.flushInterval", 1*time.Minute)
 	v.Set("client.datafileURLTemplate", "https://localhost/v1/%s.json")
 	v.Set("client.eventURL", "https://logx.localhost.com/v1")
+	v.Set("client.sdkKeyRegex", "custom-regex")
 
 	v.Set("log.pretty", true)
 	v.Set("log.level", "debug")
@@ -244,6 +246,7 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_CLIENT_FLUSHINTERVAL", "1m")
 	_ = os.Setenv("OPTIMIZELY_CLIENT_DATAFILEURLTEMPLATE", "https://localhost/v1/%s.json")
 	_ = os.Setenv("OPTIMIZELY_CLIENT_EVENTURL", "https://logx.localhost.com/v1")
+	_ = os.Setenv("OPTIMIZELY_CLIENT_SDKKEYREGEX", "custom-regex")
 
 	_ = os.Setenv("OPTIMIZELY_LOG_PRETTY", "true")
 	_ = os.Setenv("OPTIMIZELY_LOG_LEVEL", "debug")

--- a/cmd/optimizely/testdata/default.yaml
+++ b/cmd/optimizely/testdata/default.yaml
@@ -24,6 +24,7 @@ client:
   flushInterval: 1m
   datafileURLTemplate: "https://localhost/v1/%s.json"
   eventURL: "https://logx.localhost.com/v1"
+  sdkKeyRegex: "custom-regex"
 admin:
   port: "3002"
   auth:

--- a/config.yaml
+++ b/config.yaml
@@ -116,6 +116,7 @@ client:
     eventURL: "https://logx.optimizely.com/v1/events"
     ## Validation Regex on the request SDK Key
     ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
+    ## https://github.com/google/re2/wiki/Syntax
     sdkKeyRegex: "^[[:alnum:]]+$"
 
 ##

--- a/config.yaml
+++ b/config.yaml
@@ -117,7 +117,7 @@ client:
     ## Validation Regex on the request SDK Key
     ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
     ## https://github.com/google/re2/wiki/Syntax
-    sdkKeyRegex: "^[[:alnum:]]+$"
+    sdkKeyRegex: "^\\w+$"
 
 ##
 ## optimizely runtime configuration can be used for debugging and profiling the go runtime.

--- a/config.yaml
+++ b/config.yaml
@@ -114,6 +114,9 @@ client:
     datafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json"
     ## URL for dispatching events.
     eventURL: "https://logx.optimizely.com/v1/events"
+    ## Validation Regex on the request SDK Key
+    ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
+    sdkKeyRegex: "^[[:alnum:]]+$"
 
 ##
 ## optimizely runtime configuration can be used for debugging and profiling the go runtime.

--- a/config/config.go
+++ b/config/config.go
@@ -77,7 +77,7 @@ func NewDefaultConfig() *AgentConfig {
 			DatafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json",
 			EventURL:            "https://logx.optimizely.com/v1/events",
 			// https://github.com/google/re2/wiki/Syntax
-			SdkKeyRegex: "^[[:alnum:]]+$",
+			SdkKeyRegex: "^\\w+$",
 		},
 		Runtime: RuntimeConfig{
 			BlockProfileRate:     0, // 0 is disabled

--- a/config/config.go
+++ b/config/config.go
@@ -76,6 +76,8 @@ func NewDefaultConfig() *AgentConfig {
 			FlushInterval:       30 * time.Second,
 			DatafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json",
 			EventURL:            "https://logx.optimizely.com/v1/events",
+			// https://github.com/google/re2/wiki/Syntax
+			SdkKeyRegex: "^[[:alnum:]]+$",
 		},
 		Runtime: RuntimeConfig{
 			BlockProfileRate:     0, // 0 is disabled
@@ -144,6 +146,7 @@ type ClientConfig struct {
 	FlushInterval       time.Duration `json:"flushInterval" default:"30s"`
 	DatafileURLTemplate string        `json:"datafileURLTemplate"`
 	EventURL            string        `json:"eventURL"`
+	SdkKeyRegex         string        `json:"sdkKeyRegex"`
 }
 
 // LogConfig holds the log configuration

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,7 +76,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, conf.Client.FlushInterval)
 	assert.Equal(t, "https://cdn.optimizely.com/datafiles/%s.json", conf.Client.DatafileURLTemplate)
 	assert.Equal(t, "https://logx.optimizely.com/v1/events", conf.Client.EventURL)
-	assert.Equal(t, "^[[:alnum:]]+$", conf.Client.SdkKeyRegex)
+	assert.Equal(t, "^\\w+$", conf.Client.SdkKeyRegex)
 
 	assert.Equal(t, 0, conf.Runtime.BlockProfileRate)
 	assert.Equal(t, 0, conf.Runtime.MutexProfileFraction)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -76,6 +76,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, conf.Client.FlushInterval)
 	assert.Equal(t, "https://cdn.optimizely.com/datafiles/%s.json", conf.Client.DatafileURLTemplate)
 	assert.Equal(t, "https://logx.optimizely.com/v1/events", conf.Client.EventURL)
+	assert.Equal(t, "^[[:alnum:]]+$", conf.Client.SdkKeyRegex)
 
 	assert.Equal(t, 0, conf.Runtime.BlockProfileRate)
 	assert.Equal(t, 0, conf.Runtime.MutexProfileFraction)

--- a/pkg/middleware/utils_test.go
+++ b/pkg/middleware/utils_test.go
@@ -20,6 +20,7 @@ package middleware
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"net/http/httptest"
 	"testing"
 
@@ -128,4 +129,14 @@ func TestCoerceTypeQuoted(t *testing.T) {
 	assert.Equal(t, "1.0a", CoerceType(`"1.0a"`))
 	assert.Equal(t, "True", CoerceType(`"True"`))
 	assert.Equal(t, "False", CoerceType(`"False"`))
+}
+
+func assertError(t *testing.T, rec *httptest.ResponseRecorder, msg string, code int) {
+	assert.Equal(t, code, rec.Code)
+
+	var actual ErrorResponse
+	err := json.Unmarshal(rec.Body.Bytes(), &actual)
+	assert.NoError(t, err)
+
+	assert.Equal(t, ErrorResponse{Error: msg}, actual)
 }

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -105,6 +105,7 @@ func (c *OptlyCache) Wait() {
 	c.wg.Wait()
 }
 
+// ErrValidationFailure is returned when the provided SDK key fails initial validation
 var ErrValidationFailure = errors.New("sdkKey failed validation")
 
 func regexValidator(sdkKeyRegex string) func(string) bool {

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -105,7 +105,7 @@ func (c *OptlyCache) Wait() {
 	c.wg.Wait()
 }
 
-var errValidationFailure = errors.New("sdkKey failed validation")
+var ErrValidationFailure = errors.New("sdkKey failed validation")
 
 func regexValidator(sdkKeyRegex string) func(string) bool {
 	r, err := regexp.Compile(sdkKeyRegex)
@@ -126,7 +126,7 @@ func defaultLoader(
 	return func(sdkKey string) (*OptlyClient, error) {
 		if !validator(sdkKey) {
 			log.Warn().Msgf("failed to validate sdk key: %q", sdkKey)
-			return &OptlyClient{}, errValidationFailure
+			return &OptlyClient{}, ErrValidationFailure
 		}
 
 		log.Info().Str("sdkKey", sdkKey).Msg("Loading Optimizely instance")

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -107,15 +107,13 @@ func (c *OptlyCache) Wait() {
 
 var errValidationFailure = errors.New("sdkKey failed validation")
 
-func regexValidator(sdkKeyRegex string) func(sdkkey string) bool {
+func regexValidator(sdkKeyRegex string) func(string) bool {
 	r, err := regexp.Compile(sdkKeyRegex)
 	if err != nil {
 		log.Fatal().Err(err).Msgf("invalid sdkKeyRegex configuration")
 	}
 
-	return func(sdkKey string) bool {
-		return r.MatchString(sdkKey)
-	}
+	return r.MatchString
 }
 
 func defaultLoader(

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -148,9 +148,9 @@ func TestDefaultRegexValidator(t *testing.T) {
 		input    string
 		expected bool
 	}{
-		{"1234567890abcdefghijklmnopqrstuzwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", true},
+		{"1234567890abcdefghijklmnopqrstuzwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_", true},
 		{"!@#$%^&*()", false},
-		{"abc123_", false},
+		{"abc123!", false},
 		{"", false},
 	}
 

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -126,6 +126,7 @@ func TestDefaultLoader(t *testing.T) {
 		BatchSize:     1234,
 		QueueSize:     5678,
 		EventURL:      "https://localhost/events",
+		SdkKeyRegex:   "sdkkey",
 	}
 
 	loader := defaultLoader(conf, mr, pcFactory, bpFactory)
@@ -136,4 +137,26 @@ func TestDefaultLoader(t *testing.T) {
 	assert.Equal(t, conf.BatchSize, bp.BatchSize)
 	assert.Equal(t, conf.QueueSize, bp.MaxQueueSize)
 	assert.Equal(t, conf.EventURL, bp.EventEndPoint)
+
+	_, err = loader("invalid!")
+	assert.Error(t, err)
+}
+
+func TestDefaultRegexValidator(t *testing.T) {
+
+	scenarios := []struct {
+		input    string
+		expected bool
+	}{
+		{"1234567890abcdefghijklmnopqrstuzwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", true},
+		{"!@#$%^&*()", false},
+		{"abc123_", false},
+		{"", false},
+	}
+
+	conf := config.NewDefaultConfig()
+	validator := regexValidator(conf.Client.SdkKeyRegex)
+	for _, scenario := range scenarios {
+		assert.Equal(t, scenario.expected, validator(scenario.input))
+	}
 }

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -37,7 +37,7 @@ def session_override_sdk_key(session_obj):
     :param session_obj: session fixture object
     :return: updated session object
     """
-    session_obj.headers['X-Optimizely-SDK-Key'] = 'xxxinvalidsdkkeyxxx'
+    session_obj.headers['X-Optimizely-SDK-Key'] = 'xxx_invalid_sdk_key_xxx'
     return session_obj
 
 

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -37,7 +37,7 @@ def session_override_sdk_key(session_obj):
     :param session_obj: session fixture object
     :return: updated session object
     """
-    session_obj.headers['X-Optimizely-SDK-Key'] = 'xxx_invalid_sdk_key_xxx'
+    session_obj.headers['X-Optimizely-SDK-Key'] = 'xxxinvalidsdkkeyxxx'
     return session_obj
 
 


### PR DESCRIPTION
## Summary
- Add validation parameter for SDK Key header `sdkKeyRegex` to client config
- Update cache loader to validate SDK Key before initializing the Optimizely client

This change allows the SDK Key found in the request header to be validated prior to making the templated URL fetch.

## Issues
- OASIS-6583
