### PR TITLE
remove code type in samples = proper code formatting?

### DIFF
--- a/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/031 - agent-notifications.md
+++ b/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/031 - agent-notifications.md
@@ -16,6 +16,7 @@ For details on the notification types, what causes them to be triggered, and the
 ## Configuration
 
 By default, the notifications endpoint is disabled. To enable it, change config.yaml:
+
 ```yaml
 # config.yaml
 api:
@@ -25,6 +26,7 @@ api:
 Or, enable it by setting an environment variable:
 
 ```shell script
+# set an env. variable
 export OPTIMIZELY_API_ENABLENOTIFICATIONS=1
 ```
 
@@ -45,6 +47,7 @@ This connection will remain open, and any notifications triggered by other reque
 To subscribe only to a particular category of notifications, add a `filter` query parameter. For example, to subscribe only to Decision notifications:
 
 ```shell script
+# filter on decision notifications
 curl -N -H "Accept:text/event-stream" -H "X-Optimizely-Sdk-Key:<YOUR SDK KEY>"\
   http://localhost:8080/v1/notifications/event-stream?filter=decision
 ```

--- a/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/031 - agent-notifications.md
+++ b/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/031 - agent-notifications.md
@@ -17,7 +17,7 @@ For details on the notification types, what causes them to be triggered, and the
 
 By default, the notifications endpoint is disabled. To enable it, change config.yaml:
 
-```yaml
+```
 # config.yaml
 api:
     enableNotifications: true
@@ -25,7 +25,7 @@ api:
 
 Or, enable it by setting an environment variable:
 
-```shell script
+```
 # set an env. variable
 export OPTIMIZELY_API_ENABLENOTIFICATIONS=1
 ```
@@ -34,7 +34,7 @@ export OPTIMIZELY_API_ENABLENOTIFICATIONS=1
 
 Send a `GET` request to `/v1/notifications/event-stream` to subscribe:
 
-```shell script
+```
 curl -N -H "Accept:text/event-stream" -H "X-Optimizely-Sdk-Key:<YOUR SDK KEY>"\
   http://localhost:8080/v1/notifications/event-stream
 ```
@@ -46,7 +46,7 @@ This connection will remain open, and any notifications triggered by other reque
 
 To subscribe only to a particular category of notifications, add a `filter` query parameter. For example, to subscribe only to Decision notifications:
 
-```shell script
+```
 # filter on decision notifications
 curl -N -H "Accept:text/event-stream" -H "X-Optimizely-Sdk-Key:<YOUR SDK KEY>"\
   http://localhost:8080/v1/notifications/event-stream?filter=decision

--- a/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/040 - advanced-configuration.md
+++ b/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/040 - advanced-configuration.md
@@ -43,7 +43,7 @@ client:
 Set the polling interval with a shell script:
 
 ```shell script
-// Set environment variable for pollingInterval, nested inside client
+# Set environment variable for pollingInterval, nested inside client
 export OPTIMIZELY_CLIENT_POLLINGINTERVAL=120s
 ```
 

--- a/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/040 - advanced-configuration.md
+++ b/docs/readme-sync/deploy-as-a-microservice/040 - configure-optimizely-agent/040 - advanced-configuration.md
@@ -24,7 +24,7 @@ Internally, Optimizely Agent uses the [Viper](https://github.com/spf13/viper) li
 
 The default location of the config file is `config.yaml` in the root directory. If you want to specify another location, use the `OPTIMIZELY_CONFIG_FILENAME` environment variable:
 
-```bash
+```
 OPTIMIZELY_CONFIG_FILENAME=/path/to/other_config_file.yaml make run
 ```
 
@@ -34,7 +34,7 @@ When setting the value of "nested" configuration options using environment varia
 
 Set the polling interval in YAML:
 
-```yaml
+```
 # Setting a nested value in a .yaml file:
 client:
     pollingInterval: 120s
@@ -42,7 +42,7 @@ client:
 
 Set the polling interval with a shell script:
 
-```shell script
+```
 # Set environment variable for pollingInterval, nested inside client
 export OPTIMIZELY_CLIENT_POLLINGINTERVAL=120s
 ```


### PR DESCRIPTION
## Summary
Readme seems to inconsistently confuse code comments in code blocks (#) with heading markings (#). 

The "why", or other context.

## Issues
- "THING-1234" or "Fixes #123"
