### PR TITLE
test: Add open api validation in acceptance tests

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -210,7 +210,7 @@ components:
     Experiment:
       properties:
         id:
-          type: integer
+          type: string
         key:
           type: string
         variationsMap:
@@ -223,13 +223,13 @@ components:
     Feature:
       properties:
         id:
-          type: integer
+          type: string
         key:
           type: string
         variablesMap:
           type: object
           additionalProperties:
-            type: string
+            type: object
         experimentsMap:
           type: object
           additionalProperties:
@@ -239,8 +239,6 @@ components:
         - key
     Decision:
       properties:
-        #        id:
-        #          type: integer
         featureKey:
           type: string
         experimentKey:
@@ -252,17 +250,14 @@ components:
           enum:
             - feature
             - experiment
+            - ''
         enabled:
           type: boolean
         variables:
           type: object
-          additionalProperties:
-            type: string
+          additionalProperties: true
         error:
           type: string
-      required:
-        #        - id
-        - key
     ActivateContext:
       properties:
         userId:
@@ -285,8 +280,6 @@ components:
           items:
             type: string
     OverrideContext:
-      type: array
-      items:
         type: object
         properties:
           userId:
@@ -335,7 +328,7 @@ components:
         type:
           type: string
         value:
-          type: string
+          type: object
       required:
         - id
         - key
@@ -347,12 +340,12 @@ components:
           type: string
         client_secret:
           type: string
-  securitySchemes:
-    SdkKeyAuth:
-      in: header
-      name: X-Optimizely-SDK-Key
-      type: apiKey
-    TokenAuth:
-      type: http
-      scheme: bearer
-      bearerFormat: JWT
+# securitySchemes:
+#    SdkKeyAuth:
+#      in: header
+#      name: X-Optimizely-SDK-Key
+#      type: apiKey
+#    TokenAuth:
+#      type: http
+#      scheme: bearer
+#      bearerFormat: JWT

--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -340,12 +340,12 @@ components:
           type: string
         client_secret:
           type: string
-# securitySchemes:
-#    SdkKeyAuth:
-#      in: header
-#      name: X-Optimizely-SDK-Key
-#      type: apiKey
-#    TokenAuth:
-#      type: http
-#      scheme: bearer
-#      bearerFormat: JWT
+  securitySchemes:
+     SdkKeyAuth:
+       in: header
+       name: X-Optimizely-SDK-Key
+       type: apiKey
+     TokenAuth:
+       type: http
+       scheme: bearer
+       bearerFormat: JWT

--- a/tests/acceptance/helpers.py
+++ b/tests/acceptance/helpers.py
@@ -232,7 +232,7 @@ def create_and_validate_request_and_response(endpoint, method, session, bypass_v
         - response: API response object
     """
     request, request_result = create_and_validate_request(
-        endpoint, method, payload, params, session.custom_headers
+        endpoint, method, payload, params, dict(session.headers)
     )
 
     if not bypass_validation:

--- a/tests/acceptance/helpers.py
+++ b/tests/acceptance/helpers.py
@@ -168,20 +168,22 @@ def override_variation(sess, override_with):
     return resp
 
 
-def create_and_validate_request(endpoint, method, payload='', params=[]):
+def create_and_validate_request(endpoint, method, payload='', params=[], headers=[]):
     """
     Helper function to create OpenAPIRequest and validate it
     :param endpoint: API endpoint
     :param method: API request method
     :param payload: API request payload
     :param params: API request payload
+    :param headers: API request headers
     :return:
         - request: OpenAPIRequest
         - request_result: result of request validation
     """
     parameters = RequestParameters(
         query=ImmutableMultiDict(params),
-        path=endpoint
+        path=endpoint,
+        header=headers
     )
 
     request = OpenAPIRequest(
@@ -229,7 +231,10 @@ def create_and_validate_request_and_response(endpoint, method, session, bypass_v
     :return:
         - response: API response object
     """
-    request, request_result = create_and_validate_request(endpoint, method, payload, params)
+    request, request_result = create_and_validate_request(
+        endpoint, method, payload, params, session.custom_headers
+    )
+
     if not bypass_validation:
         pass
         # raise errors if request invalid

--- a/tests/acceptance/requirements.txt
+++ b/tests/acceptance/requirements.txt
@@ -1,4 +1,4 @@
 pytest>=5.3.2
 pytest-clarity>=0.2.0a1
 requests>=2.22.0
-
+openapi_core>=0.13.4

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -77,7 +77,7 @@ def pytest_addoption(parser):
     Adding CLI option to specify host URL to run tests on.
     :param parser: parser
     """
-    parser.addoption("--host", action="store", default="http//:localhost:8080",
+    parser.addoption("--host", action="store", default="http://localhost:8080",
                      help="Specify host URL to run tests on.")
 
 

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -25,8 +25,9 @@ def session_obj():
     :return: session object
     """
     s = requests.Session()
-    s.headers.update({'Content-Type': 'application/json',
-                      'X-Optimizely-SDK-Key': sdk_key})
+    s.custom_headers = {'Content-Type': 'application/json',
+                      'X-Optimizely-SDK-Key': sdk_key}
+    s.headers.update(s.custom_headers)
     return s
 
 

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -25,9 +25,8 @@ def session_obj():
     :return: session object
     """
     s = requests.Session()
-    s.custom_headers = {'Content-Type': 'application/json',
-                      'X-Optimizely-SDK-Key': sdk_key}
-    s.headers.update(s.custom_headers)
+    s.headers.update({'Content-Type': 'application/json',
+                      'X-Optimizely-SDK-Key': sdk_key})
     return s
 
 

--- a/tests/acceptance/test_acceptance/test_activate.py
+++ b/tests/acceptance/test_acceptance/test_activate.py
@@ -1,12 +1,12 @@
 import json
 import os
-
 import pytest
 import requests
+
+from tests.acceptance.helpers import create_and_validate_request_and_response
 from tests.acceptance.helpers import ENDPOINT_ACTIVATE
 from tests.acceptance.helpers import ENDPOINT_CONFIG
 from tests.acceptance.helpers import sort_response
-from tests.acceptance.helpers import create_and_validate_request_and_response
 
 BASE_URL = os.getenv('host')
 

--- a/tests/acceptance/test_acceptance/test_config.py
+++ b/tests/acceptance/test_acceptance/test_config.py
@@ -150,15 +150,9 @@ def test_config_403(session_override_sdk_key):
     Test that 403 Forbidden is returned. We use invalid SDK key to trigger 403.
     :param : session_obj
     """
-    request, request_result = create_and_validate_request(ENDPOINT_CONFIG, 'get')
 
     with pytest.raises(requests.exceptions.HTTPError):
-        resp = session_override_sdk_key.post(BASE_URL + ENDPOINT_CONFIG)
-
-        response_result = create_and_validate_response(request, resp)
-
-        # raise errors if response invalid
-        response_result.raise_for_errors()
+        resp = create_and_validate_request_and_response(ENDPOINT_CONFIG, 'get', session_override_sdk_key)
 
         assert resp.status_code == 403
         assert resp.json()['error'] == 'unable to fetch fresh datafile (consider ' \

--- a/tests/acceptance/test_acceptance/test_config.py
+++ b/tests/acceptance/test_acceptance/test_config.py
@@ -4,8 +4,6 @@ import pytest
 import requests
 
 from tests.acceptance.helpers import ENDPOINT_CONFIG
-from tests.acceptance.helpers import create_and_validate_request
-from tests.acceptance.helpers import create_and_validate_response
 from tests.acceptance.helpers import create_and_validate_request_and_response
 
 BASE_URL = os.getenv('host')

--- a/tests/acceptance/test_acceptance/test_config.py
+++ b/tests/acceptance/test_acceptance/test_config.py
@@ -4,6 +4,9 @@ import pytest
 import requests
 
 from tests.acceptance.helpers import ENDPOINT_CONFIG
+from tests.acceptance.helpers import create_and_validate_request
+from tests.acceptance.helpers import create_and_validate_response
+from tests.acceptance.helpers import create_and_validate_request_and_response
 
 BASE_URL = os.getenv('host')
 
@@ -136,19 +139,26 @@ def test_config(session_obj):
     as well.
     :param session_obj: session object
     """
-    resp = session_obj.get(BASE_URL + ENDPOINT_CONFIG)
+    resp = create_and_validate_request_and_response(ENDPOINT_CONFIG, 'get', session_obj)
     assert resp.status_code == 200
     resp.raise_for_status()
     assert json.loads(expected_config) == resp.json()
 
 
-def test_activate_403(session_override_sdk_key):
+def test_config_403(session_override_sdk_key):
     """
     Test that 403 Forbidden is returned. We use invalid SDK key to trigger 403.
     :param : session_obj
     """
+    request, request_result = create_and_validate_request(ENDPOINT_CONFIG, 'get')
+
     with pytest.raises(requests.exceptions.HTTPError):
         resp = session_override_sdk_key.post(BASE_URL + ENDPOINT_CONFIG)
+
+        response_result = create_and_validate_response(request, resp)
+
+        # raise errors if response invalid
+        response_result.raise_for_errors()
 
         assert resp.status_code == 403
         assert resp.json()['error'] == 'unable to fetch fresh datafile (consider ' \

--- a/tests/acceptance/test_acceptance/test_overrides.py
+++ b/tests/acceptance/test_acceptance/test_overrides.py
@@ -129,18 +129,9 @@ def test_overrides_403(session_override_sdk_key):
     payload = '{"userId": "matjaz",'\
                '"experimentKey": "ab_test1", "variationKey": "my_new_variation"}'
 
-    request, request_result = create_and_validate_request(ENDPOINT_OVERRIDE, 'post', payload= payload)
-
-    # raise errors if request invalid
-    request_result.raise_for_errors()
-
     with pytest.raises(requests.exceptions.HTTPError):
-        resp = session_override_sdk_key.post(BASE_URL + ENDPOINT_OVERRIDE, json=payload)
-
-        response_result = create_and_validate_response(request, resp)
-
-        # raise errors if response invalid
-        response_result.raise_for_errors()
+        resp = create_and_validate_request_and_response(ENDPOINT_OVERRIDE, 'post', session_override_sdk_key,
+                                                        payload=payload)
 
         assert resp.status_code == 403
         assert resp.json()['error'] == 'unable to fetch fresh datafile (consider ' \

--- a/tests/acceptance/test_acceptance/test_overrides.py
+++ b/tests/acceptance/test_acceptance/test_overrides.py
@@ -1,15 +1,12 @@
 import json
-
 import os
-
 import pytest
 import requests
-from tests.acceptance.helpers import ENDPOINT_OVERRIDE
+
 from tests.acceptance.helpers import activate_experiment
-from tests.acceptance.helpers import override_variation
-from tests.acceptance.helpers import create_and_validate_request
-from tests.acceptance.helpers import create_and_validate_response
 from tests.acceptance.helpers import create_and_validate_request_and_response
+from tests.acceptance.helpers import ENDPOINT_OVERRIDE
+from tests.acceptance.helpers import override_variation
 
 
 BASE_URL = os.getenv('host')

--- a/tests/acceptance/test_acceptance/test_track.py
+++ b/tests/acceptance/test_acceptance/test_track.py
@@ -54,19 +54,9 @@ def test_track_403(session_override_sdk_key):
     payload = '{"userId": "matjaz", "userAttributes": {"attr_1": "hola"}}'
     params = {"eventKey": "myevent"}
 
-    request, request_result = create_and_validate_request(ENDPOINT_TRACK, 'post', payload=payload, params=params)
-
-    # raise errors if request invalid
-    request_result.raise_for_errors()
-
     with pytest.raises(requests.exceptions.HTTPError):
-        resp = session_override_sdk_key.post(BASE_URL + ENDPOINT_TRACK, params=params,
-                                             json=json.loads(payload))
-
-        response_result = create_and_validate_response(request, resp)
-
-        # raise errors if response invalid
-        response_result.raise_for_errors()
+        resp = create_and_validate_request_and_response(ENDPOINT_TRACK, 'post', session_override_sdk_key,
+                                                        payload=payload, params=params)
 
         assert resp.status_code == 403
         assert resp.json()['error'] == 'unable to fetch fresh datafile (consider ' \

--- a/tests/acceptance/test_acceptance/test_track.py
+++ b/tests/acceptance/test_acceptance/test_track.py
@@ -1,14 +1,11 @@
 import json
-
 import os
-
 import pytest
 import requests
 
-from tests.acceptance.helpers import ENDPOINT_TRACK
-from tests.acceptance.helpers import create_and_validate_request
-from tests.acceptance.helpers import create_and_validate_response
 from tests.acceptance.helpers import create_and_validate_request_and_response
+from tests.acceptance.helpers import ENDPOINT_TRACK
+
 
 BASE_URL = os.getenv('host')
 


### PR DESCRIPTION
## Summary
This adds open API request and response validation in acceptance tests. 

## Testplan
Modified acceptance tests which are covering most of the scenarios and used openapi spec to validate that. All must pass.

## Issues
OASIS-6781