### PR TITLE
fix: Removed vulnerable version coreos/etcd

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,19 +24,6 @@ require (
 	gopkg.in/yaml.v2 v2.2.4
 )
 
-exclude (
-	github.com/coreos/etcd v3.3.10+incompatible
-	github.com/coreos/etcd v3.3.11+incompatible
-	github.com/coreos/etcd v3.3.12+incompatible
-	github.com/coreos/etcd v3.3.13+incompatible
-	github.com/coreos/etcd v3.3.15+incompatible
-	github.com/coreos/etcd v3.3.16+incompatible
-	github.com/coreos/etcd v3.3.17+incompatible
-	github.com/coreos/etcd v3.3.18+incompatible
-	github.com/coreos/etcd v3.3.19+incompatible
-	github.com/coreos/etcd v3.3.20+incompatible
-	github.com/coreos/etcd v3.3.21+incompatible
-	github.com/gorilla/websocket v1.4.0
-)
+exclude github.com/gorilla/websocket v1.4.0
 
-replace github.com/coreos/etcd v3.3.22+incompatible => github.com/etcd-io/etcd v3.3.25+incompatible
+replace github.com/coreos/etcd v3.3.10+incompatible => github.com/etcd-io/etcd v3.3.25+incompatible

--- a/go.mod
+++ b/go.mod
@@ -38,3 +38,5 @@ exclude (
 	github.com/coreos/etcd v3.3.21+incompatible
 	github.com/gorilla/websocket v1.4.0
 )
+
+replace github.com/coreos/etcd v3.3.22+incompatible => github.com/etcd-io/etcd v3.3.25+incompatible

--- a/go.sum
+++ b/go.sum
@@ -23,6 +23,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
+github.com/etcd-io/etcd v3.3.25+incompatible/go.mod h1:cdZ77EstHBwVtD6iTgzgvogwcjo9m4iOqoijouPJ4bs=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=

--- a/go.sum
+++ b/go.sum
@@ -12,7 +12,6 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
-github.com/coreos/etcd v3.3.22+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
 github.com/coreos/go-semver v0.2.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=


### PR DESCRIPTION
## Summary
- coreos/etc  was vulnerable and  dependency link is changed. Replaced with that link.

## Issues
OASIS-6869
