### PR TITLE
chore: update go sdk to 1.4.0 and add stub for GetDatafile in TestProjectConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## [2.2.0] - October 5, 2020
+- Update to Optimizely Go SDK 1.4.0 with version audience condition evaluation based on semantic versioning as well as support for number 'greater than or equal to' and 'less than or equal to'.
+
 ## [2.1.0] - September 23, 2020
 - For `server.allowedHosts` configuration property, add support for matching all subdomains of a host, or all hosts
 - Adding batching for agent (/v1/batch endpoint), including requests in parallel

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/go-kit/kit v0.9.0
 	github.com/google/uuid v1.1.1
 	github.com/lestrrat-go/jwx v0.9.0
-	github.com/optimizely/go-sdk v1.3.0
+	github.com/optimizely/go-sdk v1.4.0
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/zerolog v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742 h1:Esafd1046DLD
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
-github.com/optimizely/go-sdk v1.3.0 h1:js9Cd5uTe8mWQuY66CsXperRueOjOE6UNN1mKGkEk1M=
-github.com/optimizely/go-sdk v1.3.0/go.mod h1:ehZPiEzNzNJw98EFrZX1C9h9gVgVRCiWosQEVlgivCw=
 github.com/optimizely/go-sdk v1.4.0 h1:9i6BUzqKGT5AMdSUdlrQZrmZRRhQQ9QjeielYiCCol8=
 github.com/optimizely/go-sdk v1.4.0/go.mod h1:1uinGREH+AdijSRw3qitWkvIna1e/ZGN5eymNYPjw1A=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,8 @@ github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRW
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/optimizely/go-sdk v1.3.0 h1:js9Cd5uTe8mWQuY66CsXperRueOjOE6UNN1mKGkEk1M=
 github.com/optimizely/go-sdk v1.3.0/go.mod h1:ehZPiEzNzNJw98EFrZX1C9h9gVgVRCiWosQEVlgivCw=
+github.com/optimizely/go-sdk v1.4.0 h1:9i6BUzqKGT5AMdSUdlrQZrmZRRhQQ9QjeielYiCCol8=
+github.com/optimizely/go-sdk v1.4.0/go.mod h1:1uinGREH+AdijSRw3qitWkvIna1e/ZGN5eymNYPjw1A=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6 h1:lNCW6THrCKBiJBpz8kbVGjC7MgdCGKwuvBgc7LoD6sw=
 github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6/go.mod h1:Lu3tH6HLW3feq74c2GC+jIMS/K2CFcDWnWD9XkenwhI=
 github.com/pelletier/go-toml v1.2.0 h1:T5zMGML61Wp+FlcbWjRDT7yAxhJNAiPPLOFECq181zc=

--- a/pkg/optimizely/optimizelytest/config.go
+++ b/pkg/optimizely/optimizelytest/config.go
@@ -45,6 +45,10 @@ type TestProjectConfig struct {
 	nextID               int
 }
 
+// GetDatafile returns a string representation of the environment's datafile
+func (c *TestProjectConfig) GetDatafile() string {
+	return ""
+}
 // GetProjectID returns projectID
 func (c *TestProjectConfig) GetProjectID() string {
 	return c.ProjectID


### PR DESCRIPTION
## Summary
- Update to the latest version of go sdk with version, >=, and <= for numbers support as well as datafile accessor (not yet exposed in agent) and match registry.
