### PR TITLE
Logging improvement

### DIFF
--- a/pkg/middleware/utils.go
+++ b/pkg/middleware/utils.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"net/http"
 	"strconv"
-	"strings"
 
 	"github.com/optimizely/agent/pkg/optimizely"
 
@@ -49,11 +48,9 @@ func GetOptlyClient(r *http.Request) (*optimizely.OptlyClient, error) {
 
 // GetLogger gets the logger with some info coming from http request
 func GetLogger(r *http.Request) *zerolog.Logger {
-	sdkKey := r.Header.Get(OptlySDKHeader)
 	reqID := r.Header.Get(OptlyRequestHeader)
 
-	sdkKeySplit := strings.Split(sdkKey, ":")
-	logger := log.With().Str("sdkKey", sdkKeySplit[0]).Str("requestId", reqID).Logger()
+	logger := log.With().Str("requestId", reqID).Logger()
 	return &logger
 }
 

--- a/pkg/middleware/utils_test.go
+++ b/pkg/middleware/utils_test.go
@@ -55,14 +55,11 @@ func TestGetLogger(t *testing.T) {
 	req := httptest.NewRequest("GET", "/", nil)
 
 	req.Header.Set(OptlyRequestHeader, "12345")
-	req.Header.Set(OptlySDKHeader, "some_key")
 	logger := GetLogger(req)
 	newLogger := logger.Output(out)
 	newLogger.Info().Msg("some_message")
 
 	assert.Contains(t, out.String(), `"requestId":"12345"`)
-	assert.Contains(t, out.String(), `"sdkKey":"some_key"`)
-
 }
 
 func TestGetFeature(t *testing.T) {

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -65,7 +65,7 @@ func NewCache(ctx context.Context, conf config.ClientConfig, metricsRegistry *Me
 func (c *OptlyCache) Init(sdkKeys []string) {
 	for _, sdkKey := range sdkKeys {
 		if _, err := c.GetClient(sdkKey); err != nil {
-			log.Warn().Str("sdkKey", sdkKey).Msg("Failed to initialize Optimizely Client.")
+			log.Warn().Msg("Failed to initialize Optimizely Client.")
 		}
 	}
 }
@@ -144,7 +144,7 @@ func defaultLoader(
 		var configManager SyncedConfigManager
 
 		if !validator(clientKey) {
-			log.Warn().Msgf("failed to validate sdk key: %q", sdkKey)
+			log.Warn().Msgf("failed to validate sdk key")
 			return &OptlyClient{}, ErrValidationFailure
 		}
 
@@ -158,7 +158,7 @@ func defaultLoader(
 			datafileAccessToken = clientKeySplit[1]
 		}
 
-		log.Info().Str("sdkKey", sdkKey).Msg("Loading Optimizely instance")
+		log.Info().Msg("Loading Optimizely instance")
 
 		if datafileAccessToken != "" {
 			configManager = pcFactory(

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -124,6 +124,7 @@ func WithAPIRouter(opt *APIOptions, r chi.Router) {
 		r.Use(chimw.Throttle(opt.maxConns))
 	}
 
+	r.Use(chimw.Logger)
 	r.Use(middleware.SetTime)
 	r.Use(render.SetContentType(render.ContentTypeJSON), middleware.SetRequestID)
 


### PR DESCRIPTION
## Summary
- Stop logging SDK keys. As many others also do we collect logs for search and don't want these keys to be viewable
- Log incoming API requests. Yes, there is the /metrics endpoint but we want to also see what reqs the agent is handling via logs using our existing tools.

I'm open to suggestions, e.g., if we only want to make the http logger optional (via config).