### PR TITLE
Remove github.com/optimizely/agent/statik underscore import.

### DIFF
--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/optimizely/agent/pkg/metrics"
 	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely"
-	_ "github.com/optimizely/agent/statik" // Required to serve openapi.yaml
 
 	"github.com/go-chi/chi"
 	chimw "github.com/go-chi/chi/middleware"


### PR DESCRIPTION
## Summary
- Remove underscore import (done for side effects) from file.
## Issues
- Fixes failure to run "go mod tidy".
