### PR TITLE
doc: correct the properties and example for batch API

### DIFF
--- a/api/openapi-spec/openapi.yaml
+++ b/api/openapi-spec/openapi.yaml
@@ -509,8 +509,8 @@ components:
         body:
           description: The body for the request as JSON
           type: object
-        parameters:
-          description: The parameters for the request as JSON
+        params:
+          description: The parameters for the request as JSON (value must be string)
           type: object
         headers:
           description: The headers for the request as JSON
@@ -518,9 +518,9 @@ components:
       example:   
         method: "POST"
         url: "/v1/activate"
-        operationID: 1
+        operationID: "1"
         body: {"userId": "user1"}
-        parameters: {
+        params: {
           "type": "feature",
           "experimentKey": "ab_test_experiment"}
         headers: {


### PR DESCRIPTION
## Summary
* Update the open API document for `/batch` API

The API document is different from the code implementation.


```go
type BatchOperation struct {
	Method      string                 `json:"method"`
	URL         string                 `json:"url"`
	OperationID string                 `json:"operationID"`
	Body        map[string]interface{} `json:"body"`
	Params      map[string]string      `json:"params"`
	Headers     map[string]string      `json:"headers"`
}
```

1. We expect the `operationID` field with the string type, but we see an int type in the example.
2. There is no `parameters`  field but only the `params` field used in the source code.