### PR TITLE
Chore: prepare for 2.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+## [2.5.0] - Sep 24, 2021
+
+- Introduce the following properties in the schema to support OptimizelyConfig ([PR #322](https://github.com/optimizely/agent/pull/322)):
+  - sdk key
+  - environment key
+  - attributes
+  - audiences
+  - events
+  - experimentRules and deliveryRules to OptimizelyFeature
+  - audiences to OptimizelyExperiment
+
+  - For details about this Agent release, refer to our documentation page: https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizely-agent.
+  - Upgrade to use [Go SDK v1.7.0](https://github.com/optimizely/go-sdk/tree/v1.7.0). This adds support for improved OptimizelyConfig.
+
 ## [2.4.0] - March 3, 2021
 ## New Features
 Introduce `/decide` endpoint as a new primary interface for Decide APIs, that is for retrieving feature flag status, configuration and associated experiment decisions for users ([#292](https://github.com/optimizely/agent/pull/292)).   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,26 +4,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## Unreleased
+
 ## [2.5.0] - Sep 24, 2021
 
-  - Introduce the following properties in the schema to support OptimizelyConfig ([PR #322](https://github.com/optimizely/agent/pull/322)):  
-  - sdk key
-  - environment key  
-  - attributes
-  - audiences
-  - events
-  - experimentRules and deliveryRules to OptimizelyFeature
-  - audiences to OptimizelyExperiment
-
-For details about this Agent release, refer to our documentation page: https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizely-agent.
-Upgrade to use [Go SDK v1.7.0](https://github.com/optimizely/go-sdk/tree/v1.7.0). This adds support for improved OptimizelyConfig.
+  - Add new fields (sdkKey, environmentKey, attributes, audiences, events, experimentRules, deliveryRules) to `/config` endpoint ([PR #322](https://github.com/optimizely/agent/pull/322)):  
 
 ## [2.4.0] - March 3, 2021
 ## New Features
-Introduce `/decide` endpoint as a new primary interface for Decide APIs, that is for retrieving feature flag status, configuration and associated experiment decisions for users ([#292](https://github.com/optimizely/agent/pull/292)).   
+- Introduce `/decide` endpoint as a new primary interface for Decide APIs, that is for retrieving feature flag status, configuration and associated experiment decisions for users ([#292](https://github.com/optimizely/agent/pull/292)).   
 
-For details about this Agent release, refer to our documentation page: https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizely-agent.  
+- For details about this Agent release, refer to our documentation page: https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizely-agent.  
 Upgrade to use [Go SDK v1.6.1](https://github.com/optimizely/go-sdk/tree/v1.6.1). This adds support for OptimizelyDecision.
 
 ## [2.3.1] - November 17, 2020

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,17 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## Unreleased
 ## [2.5.0] - Sep 24, 2021
 
-- Introduce the following properties in the schema to support OptimizelyConfig ([PR #322](https://github.com/optimizely/agent/pull/322)):
+  - Introduce the following properties in the schema to support OptimizelyConfig ([PR #322](https://github.com/optimizely/agent/pull/322)):  
   - sdk key
-  - environment key
+  - environment key  
   - attributes
   - audiences
   - events
   - experimentRules and deliveryRules to OptimizelyFeature
   - audiences to OptimizelyExperiment
 
-  - For details about this Agent release, refer to our documentation page: https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizely-agent.
-  - Upgrade to use [Go SDK v1.7.0](https://github.com/optimizely/go-sdk/tree/v1.7.0). This adds support for improved OptimizelyConfig.
+For details about this Agent release, refer to our documentation page: https://docs.developers.optimizely.com/full-stack/v4.0/docs/optimizely-agent.
+Upgrade to use [Go SDK v1.7.0](https://github.com/optimizely/go-sdk/tree/v1.7.0). This adds support for improved OptimizelyConfig.
 
 ## [2.4.0] - March 3, 2021
 ## New Features


### PR DESCRIPTION
## Summary
- Updated changelog, prepare for 2.5.0 release



## Issues
- OASIS-7920 https://optimizely.atlassian.net/browse/OASIS-7920
