### PR TITLE
add -a switch to push all tags per https://github.com/docker/cli/pull/2220

### DIFF
--- a/scripts/ci_upload_packages.sh
+++ b/scripts/ci_upload_packages.sh
@@ -6,8 +6,10 @@ if [[ $TRAVIS_OS_NAME == "linux" ]]; then
 
   # push docker images to dockerhub
   echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
-  # if you dont specify the tag, it'll push all image versions
-  docker push optimizely/agent
+  # if you dont specify the tag, it'll push all image versions --> No longer the default
+  # https://docs.docker.com/engine/release-notes/#20100
+  # Add -a/--all-tags to docker push docker/cli#2220
+  docker push -a optimizely/agent
 
 elif [[ $TRAVIS_OS_NAME == "osx" ]]; then
   echo "we're on osx"


### PR DESCRIPTION

## Summary
- The docker cli default is no longer to push all tagged images
- Adding the -a option per https://docs.docker.com/engine/reference/commandline/push/

## Issues
- Fixes Travis CI build https://app.travis-ci.com/github/optimizely/agent/builds/244793203

- Jira: https://optimizely.atlassian.net/browse/SRE-2133 
