### PR TITLE
fix(issue#345):  Fixes an issue with oauth/token API denying client access.

### DIFF
--- a/pkg/handlers/oauth.go
+++ b/pkg/handlers/oauth.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020, Optimizely, Inc. and contributors                        *
+ * Copyright 2020,2022 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -122,7 +122,7 @@ func (err *ClientCredentialsError) Error() string {
 func (h *OAuthHandler) verifyClientCredentials(r *http.Request) (*ClientCredentials, int, error) {
 	reqContentType := render.GetContentType(r.Header.Get("Content-Type"))
 	if reqContentType != render.ContentTypeForm {
-		return nil, http.StatusBadRequest, &ClientCredentialsError{
+		return nil, http.StatusUnsupportedMediaType, &ClientCredentialsError{
 			ErrorCode:        "invalid_request",
 			ErrorDescription: "Content-Type header value must be application/x-www-form-urlencoded",
 		}

--- a/pkg/handlers/oauth_test.go
+++ b/pkg/handlers/oauth_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020, 2021 Optimizely, Inc. and contributors                   *
+ * Copyright 2020,2021-2022 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -19,16 +19,17 @@ package handlers
 
 import (
 	"encoding/json"
-	"github.com/go-chi/chi"
-	"github.com/optimizely/agent/config"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/suite"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/go-chi/chi"
+	"github.com/optimizely/agent/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
 )
 
 type OAuthTestSuite struct {
@@ -224,6 +225,19 @@ func (s *OAuthTestSuite) TestGetAPIAccessTokenSuccess() {
 	s.NotEmpty(actual.ExpiresIn)
 }
 
+func (s *OAuthTestSuite) TestGetAPIAccessTokenFailureUnsupportedContentType() {
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/api/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusUnsupportedMediaType, rec.Code)
+}
+
 func (s *OAuthTestSuite) TestGetAdminAccessTokenSuccess() {
 	bodyValues := url.Values{}
 	bodyValues.Set("grant_type", "client_credentials")
@@ -241,6 +255,19 @@ func (s *OAuthTestSuite) TestGetAdminAccessTokenSuccess() {
 	s.Equal("bearer", actual.TokenType)
 	s.NotEmpty(actual.AccessToken)
 	s.NotEmpty(actual.ExpiresIn)
+}
+
+func (s *OAuthTestSuite) TestGetAdminAccessTokenFailureUnsupportedContentType() {
+	bodyValues := url.Values{}
+	bodyValues.Set("grant_type", "client_credentials")
+	bodyValues.Set("client_id", "optly_user")
+	bodyValues.Set("client_secret", s.secret)
+	req := httptest.NewRequest("POST", "/admin/token", strings.NewReader(bodyValues.Encode()))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.mux.ServeHTTP(rec, req)
+
+	s.Equal(http.StatusUnsupportedMediaType, rec.Code)
 }
 
 func TestOAuthTestSuite(t *testing.T) {

--- a/pkg/routers/admin.go
+++ b/pkg/routers/admin.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2020, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2020,2022 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -26,7 +26,6 @@ import (
 	"github.com/optimizely/agent/pkg/middleware"
 
 	"github.com/go-chi/chi"
-	chimw "github.com/go-chi/chi/middleware"
 	"github.com/go-chi/render"
 	"github.com/rs/zerolog/log"
 )
@@ -62,6 +61,6 @@ func NewAdminRouter(conf config.AgentConfig) http.Handler {
 	r.With(authProvider.AuthorizeAdmin).Get("/debug/pprof/symbol", pprof.Symbol)
 	r.With(authProvider.AuthorizeAdmin).Get("/debug/pprof/trace", pprof.Trace)
 
-	r.With(chimw.AllowContentType("application/json")).Post("/oauth/token", tokenHandler.CreateAdminAccessToken)
+	r.Post("/oauth/token", tokenHandler.CreateAdminAccessToken)
 	return r
 }

--- a/pkg/routers/admin_test.go
+++ b/pkg/routers/admin_test.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2020, Optimizely, Inc. and contributors                        *
+ * Copyright 2020,2022 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -43,7 +43,7 @@ func TestAdminAllowedContentTypeMiddleware(t *testing.T) {
 	// Testing supported content type
 	body = `{"email":"test@123.com"}`
 	req = httptest.NewRequest("POST", "/oauth/token", bytes.NewBuffer([]byte(body)))
-	req.Header.Add(contentTypeHeaderKey, "application/json")
+	req.Header.Add(contentTypeHeaderKey, "application/x-www-form-urlencoded")
 	rec = httptest.NewRecorder()
 	router.ServeHTTP(rec, req)
 	assert.Equal(t, http.StatusBadRequest, rec.Code)

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -152,7 +152,7 @@ func WithAPIRouter(opt *APIOptions, r chi.Router) {
 		r.With(opt.oAuthMiddleware).Get("/notifications/event-stream", opt.nStreamHandler)
 	})
 
-	r.With(createAccesstokenTimer, contentTypeMiddleware).Post("/oauth/token", opt.oAuthHandler)
+	r.With(createAccesstokenTimer).Post("/oauth/token", opt.oAuthHandler)
 
 	statikFS, err := fs.New()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes an issue with `/oauth/token` api which restricted client access. The outer middleware only allowed `application/json`  whereas internally it was again checking again for `application/x-www-form-urlencoded`.

## Issues
- https://github.com/optimizely/agent/issues/345
