### PR TITLE
refact(ups): Add support for async save call using rest UPS.

### DIFF
--- a/cmd/optimizely/main_test.go
+++ b/cmd/optimizely/main_test.go
@@ -80,6 +80,7 @@ func assertClient(t *testing.T, actual config.ClientConfig, assertUserProfileSer
 				"lookuppath": "/ups/lookup",
 				"savepath":   "/ups/save",
 				"headers":    map[string]interface{}{"content-type": "application/json"},
+				"async":      true,
 			},
 			"custom": map[string]interface{}{
 				"path": "http://test2.com",
@@ -214,6 +215,7 @@ func TestViperProps(t *testing.T) {
 			"lookuppath": "/ups/lookup",
 			"savepath":   "/ups/save",
 			"headers":    map[string]interface{}{"content-type": "application/json"},
+			"async":      true,
 		},
 		"custom": map[string]interface{}{
 			"path": "http://test2.com",
@@ -310,7 +312,7 @@ func TestViperEnv(t *testing.T) {
 	_ = os.Setenv("OPTIMIZELY_CLIENT_DATAFILEURLTEMPLATE", "https://localhost/v1/%s.json")
 	_ = os.Setenv("OPTIMIZELY_CLIENT_EVENTURL", "https://logx.localhost.com/v1")
 	_ = os.Setenv("OPTIMIZELY_CLIENT_SDKKEYREGEX", "custom-regex")
-	_ = os.Setenv("OPTIMIZELY_CLIENT_USERPROFILESERVICE", `{"default":"in-memory","services":{"in-memory":{"storagestrategy":"fifo"},"redis":{"host":"localhost:6379","password":""},"rest":{"host":"http://localhost","lookuppath":"/ups/lookup","savepath":"/ups/save","headers":{"content-type":"application/json"}},"custom":{"path":"http://test2.com"}}}`)
+	_ = os.Setenv("OPTIMIZELY_CLIENT_USERPROFILESERVICE", `{"default":"in-memory","services":{"in-memory":{"storagestrategy":"fifo"},"redis":{"host":"localhost:6379","password":""},"rest":{"host":"http://localhost","lookuppath":"/ups/lookup","savepath":"/ups/save","headers":{"content-type":"application/json"},"async":true},"custom":{"path":"http://test2.com"}}}`)
 
 	_ = os.Setenv("OPTIMIZELY_LOG_PRETTY", "true")
 	_ = os.Setenv("OPTIMIZELY_LOG_INCLUDESDKKEY", "false")

--- a/cmd/optimizely/testdata/default.yaml
+++ b/cmd/optimizely/testdata/default.yaml
@@ -46,6 +46,7 @@ client:
         savePath: "/ups/save"
         headers: 
           content-type: "application/json"
+        async: true
       custom: 
         path: "http://test2.com"
       

--- a/config.yaml
+++ b/config.yaml
@@ -153,6 +153,7 @@ client:
         #   savePath: "/ups/save"
         #   saveMethod: "POST"
         #   userIDKey: "user_id"
+        #   async: false
         #   headers: 
         #     Content-Type: "application/json"
         #     Auth-Token: "12345"

--- a/plugins/userprofileservice/README.md
+++ b/plugins/userprofileservice/README.md
@@ -113,7 +113,7 @@ return the status code `200` with json response (keep in mind that when sending 
 ```
 - `save_endpoint` should accept the following parameters in its json body or query (depending upon the method type)   
 and return the status code `200` if successful (keep in mind that `user_id` should be substituted   
-with the value of`userIDKey` from config.yaml). Request will be synchronous by default which can configured using `async` property:  
+with the value of`userIDKey` from config.yaml). Request will be synchronous by default which can be configured using `async` property:  
 
 ```
 {

--- a/plugins/userprofileservice/README.md
+++ b/plugins/userprofileservice/README.md
@@ -88,6 +88,7 @@ userProfileService:
           savePath: "/save_endpoint"
           saveMethod: "POST"
           userIDKey: "user_id"
+          async: false
           headers: 
             "header_key": "header_value"
 ```
@@ -112,7 +113,7 @@ return the status code `200` with json response (keep in mind that when sending 
 ```
 - `save_endpoint` should accept the following parameters in its json body or query (depending upon the method type)   
 and return the status code `200` if successful (keep in mind that `user_id` should be substituted   
-with the value of`userIDKey` from config.yaml):  
+with the value of`userIDKey` from config.yaml). Request will be synchronous by default which can configured using `async` property:  
 
 ```
 {

--- a/plugins/userprofileservice/services/rest_ups.go
+++ b/plugins/userprofileservice/services/rest_ups.go
@@ -42,6 +42,7 @@ type RestUserProfileService struct {
 	SavePath     string            `json:"savePath"`
 	SaveMethod   string            `json:"saveMethod"`
 	UserIDKey    string            `json:"userIDKey"`
+	Async        bool              `json:"async"`
 }
 
 // Lookup is used to retrieve past bucketing decisions for users
@@ -82,7 +83,12 @@ func (r *RestUserProfileService) Save(profile decision.UserProfile) {
 	if err != nil {
 		return
 	}
-	r.performRequest(requestURL, r.SaveMethod, convertUserProfileToMap(profile, r.getUserIDKey()))
+	userProfileMap := convertUserProfileToMap(profile, r.getUserIDKey())
+	if r.Async {
+		go r.performRequest(requestURL, r.SaveMethod, userProfileMap)
+		return
+	}
+	r.performRequest(requestURL, r.SaveMethod, userProfileMap)
 }
 
 func (r *RestUserProfileService) getURL(endpointPath string) (string, error) {

--- a/plugins/userprofileservice/services/rest_ups_test.go
+++ b/plugins/userprofileservice/services/rest_ups_test.go
@@ -22,6 +22,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/go-chi/render"
 	"github.com/optimizely/agent/pkg/handlers"
@@ -175,9 +176,26 @@ func (rups *RestUPSTestSuite) TestSaveDefaultPOST() {
 	rups.Equal("POST", rups.MethodUsed)
 }
 
+func (rups *RestUPSTestSuite) TestSaveDefaultPOSTAsync() {
+	rups.ups.Async = true
+	rups.ups.Save(rups.userProfile)
+	time.Sleep(100 * time.Millisecond)
+	rups.Equal(rups.userProfile, rups.savedUserProfile)
+	rups.Equal("POST", rups.MethodUsed)
+}
+
 func (rups *RestUPSTestSuite) TestSaveWithGetMethod() {
 	rups.ups.SaveMethod = "GET"
 	rups.ups.Save(rups.userProfile)
+	rups.Equal(rups.userProfile, rups.savedUserProfile)
+	rups.Equal("GET", rups.MethodUsed)
+}
+
+func (rups *RestUPSTestSuite) TestSaveWithGetMethodAsync() {
+	rups.ups.Async = true
+	rups.ups.SaveMethod = "GET"
+	rups.ups.Save(rups.userProfile)
+	time.Sleep(100 * time.Millisecond)
 	rups.Equal(rups.userProfile, rups.savedUserProfile)
 	rups.Equal("GET", rups.MethodUsed)
 }


### PR DESCRIPTION
## Summary
- This adds support for asynchronous `Save` using `rest` UPS by setting `async` boolean value inside `config.yaml`.

```
userProfileService:
      default: "rest"
      services:
        rest: 
          async: true
```

## Tests
- Added new unit tests.
- All previous tests should pass.
