### PR TITLE
FSSDK-8042 (apple-silicon): Fix linter compatibility issues with apple silicon

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -9,7 +9,7 @@ on:
     branches: [ master ]
 
 env:
-  GIMME_GO_VERSION: 1.13.x 
+  GIMME_GO_VERSION: 1.16.x 
   GIMME_OS: linux 
   GIMME_ARCH: amd64
   
@@ -20,7 +20,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - name: fmt
       run: |
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - name: coveralls
       id: coveralls
@@ -67,7 +67,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - name: sourceclear
       env:
@@ -100,7 +100,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - name: Set up Python 3.9
       uses: actions/setup-python@v3
@@ -126,7 +126,7 @@ jobs:
         fetch-depth: 0
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - name: Get the version
       id: get_version
@@ -155,7 +155,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - uses: actions/checkout@v2
       with:
@@ -214,7 +214,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-go@v2
       with:
-        go-version: '1.13'
+        go-version: '1.16'
         check-latest: true
     - uses: actions/checkout@v2
       with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -65,4 +65,4 @@ issues:
  exclude-use-default: false
 
 service:
- golangci-lint-version: 1.17.x
+ golangci-lint-version: 1.44.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ language: shell
 env:
   global:
     # GO VERSION is set here with GIMME_GO_VERSION see: https://github.com/travis-ci/gimme
-    # may also want to run `go mod edit -go=1.13` to fix go.mod as well
-    - GIMME_GO_VERSION=1.13.x GIMME_OS=linux GIMME_ARCH=amd64
+    # may also want to run `go mod edit -go=1.16` to fix go.mod as well
+    - GIMME_GO_VERSION=1.16.x GIMME_OS=linux GIMME_ARCH=amd64
 
 branches:
   only:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.7.1] - December 20, 2022
+
+- Add support for asynchronous `Save` using `rest` UPS by setting `async` boolean value inside `config.yaml` ([#350](https://github.com/optimizely/agent/pull/350)).
+
 ## [2.7.0] - April 6, 2022
 
 - Add `UserProfileService` support. Out of the box implementations include `in-memory`, `rest` and `redis`. In-memory service supports both `fifo` and `lifo` orders. For details refer to our documentation page:  [UserProfileService](https://github.com/optimizely/agent/tree/master/plugins/userprofileservice) ([#326](https://github.com/optimizely/agent/pull/326), [#331](https://github.com/optimizely/agent/pull/331)).

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ build: $(TARGET) check-go ## builds and installs binary in bin/
 
 check-go:
 ifndef GOPATH
-	$(error "go is not available please install golang version 1.13+, https://golang.org/dl/")
+	$(error "go is not available please install golang version 1.16+, https://golang.org/dl/")
 endif
 
 clean: check-go ## runs `go clean` and removes the bin/ dir
@@ -51,7 +51,8 @@ cover-html: cover ## generates test coverage html report
 
 setup: check-go ## installs all dev and ci dependencies, but does not install golang
 ifeq (,$(wildcard $(GOLINT)))
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.19.0
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.50.1
+
 endif
 ifeq (,$(wildcard $(GOPATH)/bin/statik))
 	go get github.com/rakyll/statik

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ ifeq (,$(wildcard $(GOLINT)))
 
 endif
 ifeq (,$(wildcard $(GOPATH)/bin/statik))
-	go get github.com/rakyll/statik
+	GO111MODULE=off go get -u github.com/rakyll/statik
 endif
 
 lint: check-go static ## runs `golangci-lint` linters defined in `.golangci.yml` file

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ cover-html: cover ## generates test coverage html report
 
 setup: check-go ## installs all dev and ci dependencies, but does not install golang
 ifeq (,$(wildcard $(GOLINT)))
-	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.50.1
+	curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s -- -b $(GOPATH)/bin v1.44.2
 
 endif
 ifeq (,$(wildcard $(GOPATH)/bin/statik))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Optimizely Full Stack is A/B testing and feature flag management for product dev
 To get started with Optimizely Agent, follow the [Quickstart guide](https://docs.developers.optimizely.com/full-stack/docs/) and view example usage in our [examples folder](./examples).
 
 ## Prerequisites
-Optimizely Agent is implemented in [Golang](https://golang.org/). Golang version 1.13+ is required for developing and compiling from source.
+Optimizely Agent is implemented in [Golang](https://golang.org/). Golang version 1.16+ is required for developing and compiling from source.
 Installers and binary archives for most platforms can be downloaded directly from the Go [downloads](https://golang.org/dl/) page.
 
 ## Running from source (Linux / OSX)

--- a/docs/readme-sync/v3.1/deploy-as-a-microservice/020 - setup-optimizely-agent.md
+++ b/docs/readme-sync/v3.1/deploy-as-a-microservice/020 - setup-optimizely-agent.md
@@ -12,7 +12,7 @@ updatedAt: "2020-03-31T23:54:17.841Z"
 
 To develop and compile Optimizely Agent from source:
 
-1. Install  [Golang](https://golang.org/dl/)  version 1.13+ .
+1. Install  [Golang](https://golang.org/dl/)  version 1.16+ .
 2. Clone the [Optimizely Agent repo](https://github.com/optimizely/agent). 
 3. From the repo directory, open a terminal and start Optimizely Agent:
 

--- a/docs/readme-sync/v4.0/deploy-as-a-microservice/020 - setup-optimizely-agent.md
+++ b/docs/readme-sync/v4.0/deploy-as-a-microservice/020 - setup-optimizely-agent.md
@@ -12,7 +12,7 @@ updatedAt: "2021-03-15T23:02:34.056Z"
 
 To develop and compile Optimizely Agent from source:
 
-1. Install  [Golang](https://golang.org/dl/)  version 1.13+ .
+1. Install  [Golang](https://golang.org/dl/)  version 1.16+ .
 2. Clone the [Optimizely Agent repo](https://github.com/optimizely/agent). 
 3. From the repo directory, open a terminal and start Optimizely Agent:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/optimizely/agent
 
-go 1.13
+go 1.16
 
 require (
 	github.com/VividCortex/gohistogram v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,7 +63,6 @@ github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:W
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
@@ -71,7 +70,6 @@ github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/uuid v1.1.1 h1:Gkbcsh/GbpXz7lPftLA3P6TYMwjCLYm83jiFQZF/3gY=
@@ -243,7 +241,6 @@ golang.org/x/tools v0.0.0-20201224043029-2b0845dc783e/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
@@ -256,7 +253,6 @@ google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miE
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 google.golang.org/protobuf v1.23.0/go.mod h1:EGpADcykh3NcUnDUJcl1+ZksZNG86OlYog2l/sGQquU=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
-google.golang.org/protobuf v1.26.0 h1:bxAC2xTBsZGibn2RTntX0oH50xLsqy1OxA9tTL3p/lk=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/handlers/activate.go
+++ b/pkg/handlers/activate.go
@@ -97,7 +97,7 @@ func Activate(w http.ResponseWriter, r *http.Request) {
 			}
 			err = nil
 		default:
-			err = fmt.Errorf(`type "%s" not supported`, value)
+			err = fmt.Errorf(`type %q not supported`, value)
 		}
 
 		if err != nil {
@@ -145,7 +145,7 @@ func parseTypeParameter(types []string, oConf *config.OptimizelyConfig, kmap key
 				kmap[key] = "feature"
 			}
 		default:
-			return fmt.Errorf(`type "%s" not supported`, filterType)
+			return fmt.Errorf(`type %q not supported`, filterType)
 		}
 	}
 

--- a/pkg/handlers/utils.go
+++ b/pkg/handlers/utils.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2023, Optimizely, Inc. and contributors                   *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -20,7 +20,7 @@ package handlers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 
 	"github.com/go-chi/render"
@@ -44,11 +44,11 @@ func RenderError(err error, status int, w http.ResponseWriter, r *http.Request) 
 // into the provided interface. Note that we're sanitizing the returned error
 // so that it is not leaked back to the requestor.
 func ParseRequestBody(r *http.Request, v interface{}) error {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		msg := "error reading request body"
 		middleware.GetLogger(r).Error().Err(err).Msg(msg)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	if len(body) == 0 {
@@ -60,7 +60,7 @@ func ParseRequestBody(r *http.Request, v interface{}) error {
 	if err != nil {
 		msg := "error parsing request body"
 		middleware.GetLogger(r).Error().Err(err).Msg(msg)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	return nil

--- a/pkg/handlers/webhook.go
+++ b/pkg/handlers/webhook.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2023 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -23,10 +23,11 @@ import (
 	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
-	"github.com/optimizely/agent/config"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strconv"
+
+	"github.com/optimizely/agent/config"
 
 	"github.com/go-chi/render"
 	"github.com/rs/zerolog/log"
@@ -94,7 +95,7 @@ func (h *OptlyWebhookHandler) validateSignature(requestSignature string, payload
 
 // HandleWebhook handles incoming webhook messages from Optimizely application
 func (h *OptlyWebhookHandler) HandleWebhook(w http.ResponseWriter, r *http.Request) {
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		log.Error().Msg("Unable to read webhook message body.")
 		render.Status(r, http.StatusBadRequest)

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019, Optimizely, Inc. and contributors                        *
+ * Copyright 2019,2023 Optimizely, Inc. and contributors                    *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -33,6 +33,30 @@ const (
 	TimerPrefix   = "timer"
 )
 
+// Registry initializes expvar metrics registry
+type Registry struct {
+	metricsCounterVars   map[string]go_kit_metrics.Counter
+	metricsGaugeVars     map[string]go_kit_metrics.Gauge
+	metricsHistogramVars map[string]go_kit_metrics.Histogram
+	metricsTimerVars     map[string]*Timer
+
+	gaugeLock     sync.RWMutex
+	counterLock   sync.RWMutex
+	histogramLock sync.RWMutex
+	timerLock     sync.RWMutex
+}
+
+// NewRegistry initializes metrics registry
+func NewRegistry() *Registry {
+
+	return &Registry{
+		metricsCounterVars:   map[string]go_kit_metrics.Counter{},
+		metricsGaugeVars:     map[string]go_kit_metrics.Gauge{},
+		metricsHistogramVars: map[string]go_kit_metrics.Histogram{},
+		metricsTimerVars:     map[string]*Timer{},
+	}
+}
+
 // Timer is the collection of some timers
 type Timer struct {
 	hits      go_kit_metrics.Counter
@@ -62,30 +86,6 @@ func (t *Timer) Update(delta float64) {
 	t.hits.Add(1)
 	t.totalTime.Add(delta)
 	t.histogram.Observe(delta)
-}
-
-// Registry initializes expvar metrics registry
-type Registry struct {
-	metricsCounterVars   map[string]go_kit_metrics.Counter
-	metricsGaugeVars     map[string]go_kit_metrics.Gauge
-	metricsHistogramVars map[string]go_kit_metrics.Histogram
-	metricsTimerVars     map[string]*Timer
-
-	gaugeLock     sync.RWMutex
-	counterLock   sync.RWMutex
-	histogramLock sync.RWMutex
-	timerLock     sync.RWMutex
-}
-
-// NewRegistry initializes metrics registry
-func NewRegistry() *Registry {
-
-	return &Registry{
-		metricsCounterVars:   map[string]go_kit_metrics.Counter{},
-		metricsGaugeVars:     map[string]go_kit_metrics.Gauge{},
-		metricsHistogramVars: map[string]go_kit_metrics.Histogram{},
-		metricsTimerVars:     map[string]*Timer{},
-	}
 }
 
 // GetCounter gets go-kit expvar Counter

--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -249,14 +249,14 @@ func getUserProfileService(sdkKey string, userProfileServiceMap cmap.ConcurrentM
 						success := true
 						// Trying to map userProfileService from client config to struct
 						if upsConfig, err := json.Marshal(userProfileServiceConfig); err != nil {
-							log.Warn().Err(err).Msgf(`Error marshaling user profile service config: "%s"`, upsName)
+							log.Warn().Err(err).Msgf(`Error marshaling user profile service config: %q`, upsName)
 							success = false
 						} else if err := json.Unmarshal(upsConfig, upsInstance); err != nil {
-							log.Warn().Err(err).Msgf(`Error unmarshalling user profile service config: "%s"`, upsName)
+							log.Warn().Err(err).Msgf(`Error unmarshalling user profile service config: %q`, upsName)
 							success = false
 						}
 						if success {
-							log.Info().Msgf(`UserProfileService of type: "%s" created for sdkKey: "%s"`, upsName, sdkKey)
+							log.Info().Msgf(`UserProfileService of type: %q created for sdkKey: %q`, upsName, sdkKey)
 							return upsInstance
 						}
 					}

--- a/pkg/optimizely/optimizelytest/config.go
+++ b/pkg/optimizely/optimizelytest/config.go
@@ -1,5 +1,5 @@
 /****************************************************************************
- * Copyright 2019-2021, Optimizely, Inc. and contributors                   *
+ * Copyright 2019-2021,2023 Optimizely, Inc. and contributors               *
  *                                                                          *
  * Licensed under the Apache License, Version 2.0 (the "License");          *
  * you may not use this file except in compliance with the License.         *
@@ -150,7 +150,7 @@ func (c *TestProjectConfig) GetAttributeByKey(key string) (entities.Attribute, e
 		return c.AttributeMap[attributeID], nil
 	}
 
-	errMessage := fmt.Sprintf(`Attribute with key "%s" not found`, key)
+	errMessage := fmt.Sprintf(`Attribute with key %q not found`, key)
 	return entities.Attribute{}, errors.New(errMessage)
 }
 
@@ -192,7 +192,7 @@ func (c *TestProjectConfig) GetAudienceByID(audienceID string) (entities.Audienc
 		return audience, nil
 	}
 
-	errMessage := fmt.Sprintf(`Audience with ID "%s" not found`, audienceID)
+	errMessage := fmt.Sprintf(`Audience with ID %q not found`, audienceID)
 	return entities.Audience{}, errors.New(errMessage)
 }
 
@@ -208,7 +208,7 @@ func (c *TestProjectConfig) GetExperimentByKey(experimentKey string) (entities.E
 		return experiment, nil
 	}
 
-	errMessage := fmt.Sprintf(`Experiment with key "%s" not found`, experimentKey)
+	errMessage := fmt.Sprintf(`Experiment with key %q not found`, experimentKey)
 	return entities.Experiment{}, errors.New(errMessage)
 }
 

--- a/pkg/optimizely/optimizelytest/config.go
+++ b/pkg/optimizely/optimizelytest/config.go
@@ -218,7 +218,7 @@ func (c *TestProjectConfig) GetGroupByID(groupID string) (entities.Group, error)
 		return group, nil
 	}
 
-	errMessage := fmt.Sprintf(`Group with ID "%s" not found`, groupID)
+	errMessage := fmt.Sprintf(`Group with ID %q not found`, groupID)
 	return entities.Group{}, errors.New(errMessage)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -51,7 +51,7 @@ type HealthInfo struct {
 func NewServer(name, port string, handler http.Handler, conf config.ServerConfig) (Server, error) {
 
 	if handler == nil {
-		return Server{}, fmt.Errorf(`"%s" handler is not initialized`, name)
+		return Server{}, fmt.Errorf(`%q handler is not initialized`, name)
 	}
 
 	handler = middleware.BatchRouter(conf.BatchRequests)(handler)

--- a/pkg/server/server_group.go
+++ b/pkg/server/server_group.go
@@ -57,7 +57,7 @@ func NewGroup(ctx context.Context, conf config.ServerConfig) *Group {
 func (g *Group) GoListenAndServe(name, port string, handler http.Handler) {
 
 	if port == "0" {
-		log.Info().Msg(fmt.Sprintf(`"%s" not enabled`, name))
+		log.Info().Msg(fmt.Sprintf(`%q not enabled`, name))
 		return
 	}
 

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -101,7 +101,7 @@ function main($mode) {
     # noninteractive mode: ./build.ps1 noninteractive (default: interactive)
 
     # check if go is installed, if not, install it.
-    checkPrereq 'Go Programming Language amd64 go1.13.5' https://dl.google.com/go/go1.13.5.windows-amd64.msi eabcf66d6d8f44de21a96a18d957990c62f21d7fadcb308a25c6b58c79ac2b96 $mode
+    checkPrereq 'Go Programming Language amd64 go1.16' https://dl.google.com/go/go1.16.windows-amd64.msi 0fd550a74f6c8ef5df405751f5e39a0ba25786930c5d61503bf71d3c3efa2414 $mode
     # same but with git
     checkPrereq 'Git version 2.24.1.2' https://github.com/git-for-windows/git/releases/download/v2.24.1.windows.2/Git-2.24.1.2-64-bit.exe 34e484936105713e7d0c2f421bf62e4cfe652f6638a9ecb5df2186c1918753e2 $mode
 

--- a/scripts/dockerfiles/Dockerfile.alpine
+++ b/scripts/dockerfiles/Dockerfile.alpine
@@ -1,5 +1,5 @@
 ARG GO_VERSION
-FROM golang:$GO_VERSION-alpine3.10 as builder
+FROM golang:$GO_VERSION-alpine3.15 as builder
 # hadolint ignore=DL3018
 RUN addgroup -S agentgroup && adduser -S agentuser -G agentgroup
 RUN apk add --no-cache make gcc libc-dev git curl
@@ -7,7 +7,7 @@ WORKDIR /go/src/github.com/optimizely/agent
 COPY . .
 RUN make setup build
 
-FROM alpine:3.10
+FROM alpine:3.15
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/optimizely/agent/bin/optimizely /optimizely
 COPY --from=builder /etc/passwd /etc/passwd


### PR DESCRIPTION
## Summary
- Fixes linter compatibility issues with apple silicon by updating go-sdk version to `1.16` and `golangci-lint-version` version to `1.44`.

## Test plan
- All tests should pass

## Issues
- FSSDK-8042