### PR TITLE
WIP: Add ODP wrapper

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,12 +13,12 @@ require (
 	github.com/golang-jwt/jwt v3.2.1+incompatible
 	github.com/google/uuid v1.1.1
 	github.com/lestrrat-go/jwx v0.9.0
-	github.com/optimizely/go-sdk v1.8.0
+	github.com/optimizely/go-sdk v1.8.4-0.20230117172806-a96c3071c921
 	github.com/orcaman/concurrent-map v0.0.0-20190826125027-8c72a8bb44f6
 	github.com/rakyll/statik v0.1.7
 	github.com/rs/zerolog v1.18.1-0.20200514152719-663cbb4c8469
 	github.com/spf13/viper v1.4.0
-	github.com/stretchr/testify v1.7.0
+	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9
 	golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/handlers/decide.go
+++ b/pkg/handlers/decide.go
@@ -65,6 +65,10 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// TODO: (Jae) add parameter for fetch-qualified-sements
+	// check if with-odp-segment exists in the request body - same as function above or below?
+	// ...
+
 	decideOptions, err := decide.TranslateOptions(db.DecideOptions)
 	if err != nil {
 		RenderError(err, http.StatusBadRequest, w, r)
@@ -72,6 +76,8 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 	}
 
 	optimizelyUserContext := optlyClient.CreateUserContext(db.UserID, db.UserAttributes)
+
+	// TODO: (Jae) here add call fetch qual segments
 
 	// Setting up forced decisions
 	for _, fd := range db.ForcedDecisions {

--- a/pkg/handlers/fetch_qualified_segments.go
+++ b/pkg/handlers/fetch_qualified_segments.go
@@ -1,0 +1,112 @@
+/****************************************************************************
+ * Copyright 2021, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	// "fmt"
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/optimizely/agent/pkg/middleware"
+	"github.com/optimizely/go-sdk/pkg/odp/segment"
+)
+
+// FetchBody defines the request body for decide API
+type FetchBody struct {
+	UserID         string                            `json:"userId"`
+	UserAttributes map[string]interface{}            `json:"userAttributes"`
+	SegmentOptions []segment.OptimizelySegmentOption `json:"segmentOptions"`
+}
+
+// FetchQualifiedSegments fetches qualified segments from ODP platform
+func FetchQualifiedSegments(w http.ResponseWriter, r *http.Request) {
+	optlyClient, err := middleware.GetOptlyClient(r)
+	logger := middleware.GetLogger(r)
+	if err != nil {
+		RenderError(err, http.StatusInternalServerError, w, r)
+		return
+	}
+
+	db, err := getUserContextWithOdpOptions(r)
+	if err != nil {
+		RenderError(err, http.StatusBadRequest, w, r)
+		return
+	}
+
+	// TODO: MUST ADD OPTIONS FOR FETCH QUALIFIED SEGMENTS - REDO FOR FETCH QUAL SEGMENTS
+	// TODO: DO I NEED TRANSLATE FUNCTION/FILE (decide_options.go)? DO OPTIONS WORK THE SAME AS IN DECIDE OPTIONS?
+
+	// TODo: DON'T NEED TRANSLATE method, because OptimizelySegmentOption is much simpler than DecideOptions
+	// See segment_option.go file from go-sdk: https://github.com/optimizely/go-sdk/blob/master/pkg/odp/segment/segment_option.go
+	// need to mport this file
+
+	// decideOptions, err := decide.TranslateOptions(db.DecideOptions)
+	// if err != nil {
+	// 	RenderError(err, http.StatusBadRequest, w, r)
+	// 	return
+	// }
+
+	// Fetch qualified segments
+	optimizelyUserContext := optlyClient.CreateUserContext(db.UserID, db.UserAttributes)
+	// optimizelyUserContext.FetchQualifiedSegments([]segment.OptimizelySegmentOption{db.SegmentOptions}) // TODO: replace []segment.OptimizelySegmentOption{} with db.SegmentOption
+	optimizelyUserContext.FetchQualifiedSegments([]segment.OptimizelySegmentOption{[]db.SegmentOptions}) // TODO: replace []segment.OptimizelySegmentOption{} with db.SegmentOption
+	segments := optimizelyUserContext.GetQualifiedSegments()
+	print("RECEIVED SEGMENTS ", segments)
+
+	if len(segments) > 0 {
+		fmt.Printf("  >>> SEGMENTS (exist): %v", segments)
+		logger.Info().Msg("Segments")
+	} else {
+		fmt.Printf("  >>> SEGMENTS (don't exist)): %v", segments)
+		logger.Info().Msg("Segments don't exist.")
+	}
+	fmt.Println()
+
+	render.JSON(w, r, segments)
+
+	return
+}
+
+// Go uses options like so:
+// decision := user.Decide("feature1", []decide.OptimizelyDecideOptions{decide.IncludeReasons})
+// agent...
+
+func getUserContextWithOdpOptions(r *http.Request) (FetchBody, error) { // TODO: - should it say "with options"??? is that from copying from  decide
+	var body FetchBody
+	err := ParseRequestBody(r, &body)
+	if err != nil {
+		return FetchBody{}, err
+	}
+
+	if body.UserID == "" {
+		return FetchBody{}, ErrEmptyUserID
+	}
+
+	return body, nil
+}
+
+// TODO: NEXT:
+// - take care of adding options to fetchQualifiedSegments - ca be simpler, not like for DecideOptions
+// - continue completing the fetch_qualified_segments.go file
+// some unit tests complain when I upgrade go-sdk to the master - I can temporarily disable them just to test if fetch works
+//    - notification_test.go, track_test.go
+// UNIT TESTS FAILING - cause of the added ODP
+// ACCEPTANCE TESTS FAILING - keeps saying port 8080 already in use!!! only agent uses it, so what is going on?
+
+// TODO: NOW I'M TRYING TO RUN FETCH SEGMENTS TO SEE THE OUTPUT !!!!!!

--- a/pkg/handlers/fetch_qualified_segments_test.go
+++ b/pkg/handlers/fetch_qualified_segments_test.go
@@ -1,0 +1,2 @@
+// Package handlers //
+package handlers

--- a/pkg/handlers/send_odp_event.go
+++ b/pkg/handlers/send_odp_event.go
@@ -1,0 +1,74 @@
+/****************************************************************************
+ * Copyright 2021, Optimizely, Inc. and contributors                        *
+ *                                                                          *
+ * Licensed under the Apache License, Version 2.0 (the "License");          *
+ * you may not use this file except in compliance with the License.         *
+ * You may obtain a copy of the License at                                  *
+ *                                                                          *
+ *    http://www.apache.org/licenses/LICENSE-2.0                            *
+ *                                                                          *
+ * Unless required by applicable law or agreed to in writing, software      *
+ * distributed under the License is distributed on an "AS IS" BASIS,        *
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. *
+ * See the License for the specific language governing permissions and      *
+ * limitations under the License.                                           *
+ ***************************************************************************/
+
+// Package handlers //
+package handlers
+
+import (
+	"errors"
+	"net/http"
+
+	"github.com/go-chi/render"
+	"github.com/optimizely/agent/pkg/middleware"
+)
+
+// SendBody defines the request body for decide API
+type SendBody struct {
+	Action      string                 `json:"action"`
+	Type        string                 `json:"type"`
+	Identifiers map[string]string      `json:"identifiers"`
+	Data        map[string]interface{} `json:"data"`
+}
+
+// SendOdpEvent sends event to ODP platform
+func SendOdpEvent(w http.ResponseWriter, r *http.Request) {
+	optlyClient, err := middleware.GetOptlyClient(r)
+	logger := middleware.GetLogger(r)
+	if err != nil {
+		RenderError(err, http.StatusInternalServerError, w, r)
+		return
+	}
+
+	db, err := getResponseBody(r)
+	if err != nil {
+		RenderError(err, http.StatusBadRequest, w, r)
+		return
+	}
+
+	success := optlyClient.SendOdpEvent(db.Action, db.Type, db.Identifiers, db.Data)
+	logger.Info().Bool("Success", success).Msg("Success. ODP event sent.")
+
+	render.JSON(w, r, success)
+
+}
+
+var ErrIdentifiers = errors.New(`missing "identifiers" in request payload`)
+
+func getResponseBody(r *http.Request) (SendBody, error) {
+	var body SendBody
+	err := ParseRequestBody(r, &body)
+	if err != nil {
+		return SendBody{}, err
+	}
+
+	if body.Identifiers == nil { // TODO: REPLACE NIL WITH EMPTY VALUE???
+		return SendBody{}, ErrIdentifiers
+	}
+
+	// TODO: add any other error catching (for missing action, type, data?)
+
+	return body, nil
+}

--- a/pkg/handlers/send_odp_event_test.go
+++ b/pkg/handlers/send_odp_event_test.go
@@ -1,0 +1,2 @@
+// Package handlers //
+package handlers

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -1,9 +1,9 @@
 /****************************************************************************
- * Copyright 2020-2022, Optimizely, Inc. and contributors                   *
- *                                                                          *
- * Licensed under the Apache License, Version 2.0 (the "License");          *
- * you may not use this file except in compliance with the License.         *
- * You may obtain a copy of the License at                                  *
+* Copyright 2020-2022, Optimizely, Inc. and contributors                   *
+*                                                                          *
+* Licensed under the Apache License, Version 2.0 (the "License");          *
+* you may not use this file except in compliance with the License.         *
+* You may obtain a copy of the License at                                  *
  *                                                                          *
  *    http://www.apache.org/licenses/LICENSE-2.0                            *
  *                                                                          *
@@ -38,21 +38,23 @@ import (
 
 // APIOptions defines the configuration parameters for Router.
 type APIOptions struct {
-	maxConns        int
-	sdkMiddleware   func(next http.Handler) http.Handler
-	metricsRegistry *metrics.Registry
-	configHandler   http.HandlerFunc
-	datafileHandler http.HandlerFunc
-	activateHandler http.HandlerFunc
-	decideHandler   http.HandlerFunc
-	trackHandler    http.HandlerFunc
-	overrideHandler http.HandlerFunc
-	lookupHandler   http.HandlerFunc
-	saveHandler     http.HandlerFunc
-	nStreamHandler  http.HandlerFunc
-	oAuthHandler    http.HandlerFunc
-	oAuthMiddleware func(next http.Handler) http.Handler
-	corsHandler     func(next http.Handler) http.Handler
+	maxConns                      int
+	sdkMiddleware                 func(next http.Handler) http.Handler
+	metricsRegistry               *metrics.Registry
+	configHandler                 http.HandlerFunc
+	datafileHandler               http.HandlerFunc
+	activateHandler               http.HandlerFunc
+	decideHandler                 http.HandlerFunc
+	trackHandler                  http.HandlerFunc
+	overrideHandler               http.HandlerFunc
+	lookupHandler                 http.HandlerFunc
+	saveHandler                   http.HandlerFunc
+	fetchQualifiedSegmentsHandler http.HandlerFunc
+	sendOdpEventHandler           http.HandlerFunc
+	nStreamHandler                http.HandlerFunc
+	oAuthHandler                  http.HandlerFunc
+	oAuthMiddleware               func(next http.Handler) http.Handler
+	corsHandler                   func(next http.Handler) http.Handler
 }
 
 func forbiddenHandler(message string) http.HandlerFunc {
@@ -90,26 +92,29 @@ func NewDefaultAPIRouter(optlyCache optimizely.Cache, conf config.APIConfig, met
 	corsHandler := createCorsHandler(conf.CORS)
 
 	spec := &APIOptions{
-		maxConns:        conf.MaxConns,
-		metricsRegistry: metricsRegistry,
-		configHandler:   handlers.OptimizelyConfig,
-		datafileHandler: handlers.GetDatafile,
-		activateHandler: handlers.Activate,
-		decideHandler:   handlers.Decide,
-		overrideHandler: overrideHandler,
-		lookupHandler:   handlers.Lookup,
-		saveHandler:     handlers.Save,
-		trackHandler:    handlers.TrackEvent,
-		sdkMiddleware:   mw.ClientCtx,
-		nStreamHandler:  nStreamHandler,
-		oAuthHandler:    authHandler.CreateAPIAccessToken,
-		oAuthMiddleware: authProvider.AuthorizeAPI,
-		corsHandler:     corsHandler,
+		maxConns:                      conf.MaxConns,
+		metricsRegistry:               metricsRegistry,
+		configHandler:                 handlers.OptimizelyConfig,
+		datafileHandler:               handlers.GetDatafile,
+		activateHandler:               handlers.Activate,
+		decideHandler:                 handlers.Decide,
+		overrideHandler:               overrideHandler,
+		lookupHandler:                 handlers.Lookup,
+		saveHandler:                   handlers.Save,
+		trackHandler:                  handlers.TrackEvent,
+		fetchQualifiedSegmentsHandler: handlers.FetchQualifiedSegments,
+		sendOdpEventHandler:           handlers.SendOdpEvent,
+		sdkMiddleware:                 mw.ClientCtx,
+		nStreamHandler:                nStreamHandler,
+		oAuthHandler:                  authHandler.CreateAPIAccessToken,
+		oAuthMiddleware:               authProvider.AuthorizeAPI,
+		corsHandler:                   corsHandler,
 	}
 
 	return NewAPIRouter(spec)
 }
 
+// TODO: test
 // NewAPIRouter returns HTTP API router backed by an optimizely.Cache implementation
 func NewAPIRouter(opt *APIOptions) *chi.Mux {
 	r := chi.NewRouter()
@@ -117,6 +122,7 @@ func NewAPIRouter(opt *APIOptions) *chi.Mux {
 	return r
 }
 
+// TODO: NEXT - DEFINE ENDPOINT AND SCHEMA - ONE FILE PER ENDPOINT ????????
 // WithAPIRouter appends routes and middleware to the given router.
 // See https://godoc.org/github.com/go-chi/chi#Mux.Group for usage
 func WithAPIRouter(opt *APIOptions, r chi.Router) {
@@ -128,6 +134,8 @@ func WithAPIRouter(opt *APIOptions, r chi.Router) {
 	lookupTimer := middleware.Metricize("lookup", opt.metricsRegistry)
 	saveTimer := middleware.Metricize("save", opt.metricsRegistry)
 	trackTimer := middleware.Metricize("track-event", opt.metricsRegistry)
+	fetchQualifiedSegmentsTimer := middleware.Metricize("fetch-qualified-segments", opt.metricsRegistry) // TODO: fetch-qualified-segments
+	sendOdpEventTimer := middleware.Metricize("send-odp-event", opt.metricsRegistry)                     // TODO: send-odp-event
 	createAccesstokenTimer := middleware.Metricize("create-api-access-token", opt.metricsRegistry)
 	contentTypeMiddleware := chimw.AllowContentType("application/json")
 
@@ -149,6 +157,8 @@ func WithAPIRouter(opt *APIOptions, r chi.Router) {
 		r.With(overrideTimer, opt.oAuthMiddleware, contentTypeMiddleware).Post("/override", opt.overrideHandler)
 		r.With(lookupTimer, opt.oAuthMiddleware, contentTypeMiddleware).Post("/lookup", opt.lookupHandler)
 		r.With(saveTimer, opt.oAuthMiddleware, contentTypeMiddleware).Post("/save", opt.saveHandler)
+		r.With(fetchQualifiedSegmentsTimer, opt.oAuthMiddleware, contentTypeMiddleware).Post("/fetch-qualified-segments", opt.fetchQualifiedSegmentsHandler) // TODO: will go schema like dashes?
+		r.With(sendOdpEventTimer, opt.oAuthMiddleware, contentTypeMiddleware).Post("/send-odp-event", opt.sendOdpEventHandler)                               // TODO: will go schema like dashes?
 		r.With(opt.oAuthMiddleware).Get("/notifications/event-stream", opt.nStreamHandler)
 	})
 
@@ -165,8 +175,9 @@ func WithAPIRouter(opt *APIOptions, r chi.Router) {
 
 func createCorsHandler(c config.CORSConfig) func(next http.Handler) http.Handler {
 	options := cors.Options{
-		AllowedOrigins:   c.AllowedOrigins,
-		AllowedMethods:   c.AllowedMethods,
+		AllowedOrigins: c.AllowedOrigins,
+		AllowedMethods: c.AllowedMethods,
+
 		AllowedHeaders:   c.AllowedHeaders,
 		ExposedHeaders:   c.ExposedHeaders,
 		AllowCredentials: c.AllowedCredentials,


### PR DESCRIPTION
## Summary
- Add two new endpoints: 
  - fetch_qualified_segments
  - send_odp_event
- extend decide with fetching qualified segment implicitly (add argument to decide: with-odp-segments=true). This is in addition to a standalone endpoint/api fetch_qualified_segments. We will have the standalone one and the one built-into decide using extra argument
- extend config options to support ODP section (config.yaml)
- Update open api schema
- unit tests

## Issues
- FSSDK-8837 https://jira.sso.episerver.net/browse/FSSDK-8837 
