### PR TITLE
[FSSDK-8958] fix: change build status to actions

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -1,4 +1,4 @@
-name: Agent CI
+name: build
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-<!-- [![Build Status](https://travis-ci.com/optimizely/agent.svg?token=y3xM1z7bQsqHX2NTEhps&branch=master)](https://travis-ci.com/optimizely/agent) -->
-
+[![Build Status](https://github.com/optimizely/agent/actions/workflows/agent.yml/badge.svg?branch=master)](https://github.com/optimizely/agent/actions/workflows/agent.yml?query=branch%3Amaster)
 [![Coverage Status](https://coveralls.io/repos/github/optimizely/agent/badge.svg)](https://coveralls.io/github/optimizely/agent)
 
 # Optimizely Agent


### PR DESCRIPTION
## Summary

Change build status badge to git actions instead of travis.

## Issues
[FSSDK-8958](https://jira.sso.episerver.net/browse/FSSDK-8958)
