### PR TITLE
[FSSDK-8958] ci: make release check wait for release

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -208,6 +208,7 @@ jobs:
 
   test_github_release_assets:
     if: startsWith(github.ref, 'refs/tags/')
+    needs: build_upload_publish_draft
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary
- Make release check jobs reliant on release creation job

## Ticket
[FSSDK-8958](https://jira.sso.episerver.net/browse/FSSDK-8958)
