### PR TITLE
[FSSDK-8958] ci: Changed travis tag to release tag and providing it in env

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -252,7 +252,7 @@ jobs:
       run: |
         # installs hub to ~/bin
         $HOME/travisci-tools/release_github/install_hub.sh
-        echo "$HOME/bin:$HOME/travisci-tools/slack" >> $GITHUB_PATH
+        # echo "$HOME/bin:$HOME/travisci-tools/slack" >> $GITHUB_PATH
     - name: run script
       env:
         GITHUB_TOKEN: ${{ secrets.CI_USER_TOKEN }}
@@ -265,7 +265,8 @@ jobs:
         hub release download $(git describe --abbrev=0 --tags) -i '*-${{ matrix.TARGET }}-*'
         tar xvfz generate_secret-${{ matrix.TARGET }}-${APP_VERSION}.tar.gz -C /tmp
         /tmp/generate_secret
-    - name: failure
-      if: steps.script.outcome != 'success'
-      run: |
-        SLACK_TEXT="${APP_VERSION} ${{ matrix.os_name }} assets failed verification." send_to_slack.sh
+    # TODO: add step to publish outcome on teams.
+    # - name: failure
+    #   if: steps.script.outcome != 'success'
+    #   run: |
+    #     SLACK_TEXT="${APP_VERSION} ${{ matrix.os_name }} assets failed verification." send_to_slack.sh

--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -177,6 +177,7 @@ jobs:
       run: |
         TAG=${{ steps.get_version.outputs.VERSION }}
         echo "APP_VERSION=${TAG#v}" >> $GITHUB_ENV
+        echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
         echo "TRAVIS_BUILD_DIR=${{ steps.get_workspace.outputs.WORKSPACE }}" >> $GITHUB_ENV
     - name: Upload and publish draft
       env:

--- a/scripts/ci_attach_generate_secret.sh
+++ b/scripts/ci_attach_generate_secret.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-hub release edit "$TRAVIS_TAG" -m "" \
+hub release edit "$RELEASE_TAG" -m "" \
   -a "/tmp/output_packages/generate_secret-linux-amd64-$APP_VERSION.tar.gz#generate_secret $APP_VERSION for Linux 64-bit" \
   -a "/tmp/output_packages/generate_secret-darwin-amd64-$APP_VERSION.tar.gz#generate_secret $APP_VERSION for MacOS 64-bit" \
   -a "/tmp/output_packages/generate_secret-windows-amd64-$APP_VERSION.tar.gz#generate_secret $APP_VERSION for Windows 64-bit"


### PR DESCRIPTION
## Summary
- Changed travis tag to release tag and providing it in env
- Removed sending message to slack as it is no longer used by opti

## Ticket
[FSSDK-8958](https://jira.sso.episerver.net/browse/FSSDK-8958)

