### PR TITLE
[FSSDK-8839]: Added acceptance tests for send-odp-event.

### DIFF
--- a/pkg/optimizely/cache.go
+++ b/pkg/optimizely/cache.go
@@ -32,6 +32,7 @@ import (
 	sdkconfig "github.com/optimizely/go-sdk/pkg/config"
 	"github.com/optimizely/go-sdk/pkg/decision"
 	"github.com/optimizely/go-sdk/pkg/event"
+	"github.com/optimizely/go-sdk/pkg/logging"
 	"github.com/optimizely/go-sdk/pkg/odp"
 	odpEventPkg "github.com/optimizely/go-sdk/pkg/odp/event"
 	odpSegmentPkg "github.com/optimizely/go-sdk/pkg/odp/segment"
@@ -272,7 +273,7 @@ func defaultLoader(
 		segmentManager := odpSegmentPkg.NewSegmentManager(
 			sdkKey,
 			odpSegmentPkg.WithAPIManager(
-				odpSegmentPkg.NewSegmentAPIManager(sdkKey, utils.NewHTTPRequester(nil, utils.Timeout(conf.ODP.SegmentsRequestTimeout))),
+				odpSegmentPkg.NewSegmentAPIManager(sdkKey, utils.NewHTTPRequester(logging.GetLogger(sdkKey, "SegmentAPIManager"), utils.Timeout(conf.ODP.SegmentsRequestTimeout))),
 			),
 			odpSegmentPkg.WithSegmentsCache(clientODPCache),
 		)
@@ -281,7 +282,7 @@ func defaultLoader(
 		eventManager := odpEventPkg.NewBatchEventManager(
 			odpEventPkg.WithAPIManager(
 				odpEventPkg.NewEventAPIManager(
-					sdkKey, utils.NewHTTPRequester(nil, utils.Timeout(conf.ODP.EventsRequestTimeout)),
+					sdkKey, utils.NewHTTPRequester(logging.GetLogger(sdkKey, "EventAPIManager"), utils.Timeout(conf.ODP.EventsRequestTimeout)),
 				),
 			),
 			odpEventPkg.WithFlushInterval(conf.ODP.EventsFlushInterval),

--- a/tests/acceptance/helpers.py
+++ b/tests/acceptance/helpers.py
@@ -21,6 +21,7 @@ ENDPOINT_DECIDE = '/v1/decide'
 ENDPOINT_DATAFILE = '/v1/datafile'
 ENDPOINT_SAVE = '/v1/save'
 ENDPOINT_LOOKUP = '/v1/lookup'
+ENDPOINT_SEND_ODP_EVENT = '/v1/send-odp-event'
 
 YAML_FILE_PATH = os.getenv('OPENAPI_YAML_PATH', 'api/openapi-spec/openapi.yaml')
 

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -6,6 +6,8 @@ import requests
 # sdk key of the project "Agent Acceptance", under QA account
 sdk_key = "KZbunNn9bVfBWLpZPq2XC4"
 
+# Temporary sdk key for odp testing, need to discuss
+sdk_key_odp = "TbrfRLeKvLyWGusqANoeR"
 
 @pytest.fixture
 def session_obj():
@@ -23,6 +25,16 @@ def session_obj():
                       'X-Optimizely-SDK-Key': sdk_key})
     return s
 
+
+@pytest.fixture(scope='function')
+def session_override_sdk_key_odp(session_obj):
+    """
+    Override session_obj fixture with odp SDK key.
+    :param session_obj: session fixture object
+    :return: updated session object
+    """
+    session_obj.headers['X-Optimizely-SDK-Key'] = sdk_key_odp
+    return session_obj
 
 @pytest.fixture(scope='function')
 def session_override_sdk_key(session_obj):

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -6,8 +6,8 @@ import requests
 # sdk key of the project "Agent Acceptance", under QA account
 sdk_key = "KZbunNn9bVfBWLpZPq2XC4"
 
-# Temporary sdk key for odp testing, need to discuss
-sdk_key_odp = "TbrfRLeKvLyWGusqANoeR"
+# sdk key of the project "Agent Acceptance w ODP", under QA account
+sdk_key_odp = "91GuiKYH8ZF1hLLXR7DR1"
 
 @pytest.fixture
 def session_obj():

--- a/tests/acceptance/test_acceptance/test_odp_decide.py
+++ b/tests/acceptance/test_acceptance/test_odp_decide.py
@@ -8,57 +8,59 @@ from tests.acceptance.helpers import create_and_validate_request_and_response
 from tests.acceptance.helpers import sort_response
 
 expected_fetch_disabled = {
-    "variationKey": "on",
-    "enabled": True,
-    "ruleKey": "flag1_targeted_delivery",
+    "variationKey": "off",
+    "enabled": False,
+    "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
     "userContext": {
         "userId": "fs-id-1",
         "attributes": {}
     },
-    "reasons": ['an error occurred while evaluating nested tree for audience ID "22725221898"',
-                'Audiences for experiment flag1_experiment collectively evaluated to false.',
-                'User "fs-id-1" does not meet conditions to be in experiment "flag1_experiment".',
-                'Audiences for experiment flag1_targeted_delivery collectively evaluated to true.']
+    "reasons": ['an error occurred while evaluating nested tree for audience ID "23783030150"',
+                'Audiences for experiment ab_experiment collectively evaluated to false.',
+                'User "fs-id-1" does not meet conditions to be in experiment "ab_experiment".',
+                'Audiences for experiment default-rollout-52207-23726430538 collectively evaluated to true.',
+                'User "fs-id-1" meets conditions for targeting rule "Everyone Else".']
 }
 
 expected_no_segments_fetched = {
-    "variationKey": "on",
-    "enabled": True,
-    "ruleKey": "flag1_targeted_delivery",
+    "variationKey": "off",
+    "enabled": False,
+    "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
     "userContext": {
         "userId": "test_user",
         "attributes": {}
     },
-    "reasons": ['an error occurred while evaluating nested tree for audience ID "22725221898"',
-                'Audiences for experiment flag1_experiment collectively evaluated to false.',
-                'User "test_user" does not meet conditions to be in experiment "flag1_experiment".',
-                'Audiences for experiment flag1_targeted_delivery collectively evaluated to true.']
+    "reasons": ['an error occurred while evaluating nested tree for audience ID "23783030150"',
+                'Audiences for experiment ab_experiment collectively evaluated to false.',
+                'User "test_user" does not meet conditions to be in experiment "ab_experiment".',
+                'Audiences for experiment default-rollout-52207-23726430538 collectively evaluated to true.',
+                'User "test_user" meets conditions for targeting rule "Everyone Else".']
 }
 
 expected_fetch_enabled = {
-    "variationKey": "variation_a",
+    "variationKey": "variation_b",
     "enabled": True,
-    "ruleKey": "flag1_experiment",
+    "ruleKey": "ab_experiment",
     "flagKey": "flag1",
     "userContext": {
         "userId": "fs-id-1",
         "attributes": {}
     },
-    "reasons": ["Audiences for experiment flag1_experiment collectively evaluated to true."]
+    "reasons": ["Audiences for experiment ab_experiment collectively evaluated to true."]
 }
 
 expected_fetch_enabled_default_rollout = {
     "variationKey": "off",
     "enabled": False,
-    "ruleKey": "default-rollout-34903-22583870382",
+    "ruleKey": "default-rollout-52231-23726430538",
     "flagKey": "flag2",
     "userContext": {
         "userId": "fs-id-1",
         "attributes": {}
     },
-    "reasons": ['Audiences for experiment default-rollout-34903-22583870382 collectively evaluated to true.',
+    "reasons": ['Audiences for experiment default-rollout-52231-23726430538 collectively evaluated to true.',
                 'User "fs-id-1" meets conditions for targeting rule "Everyone Else".']
 }
 
@@ -74,7 +76,7 @@ expected_fetch_failed = {
         ("flag2", expected_fetch_enabled_default_rollout, 200, True, 'fs-id-1'),
         ("flag1", expected_no_segments_fetched, 200, True, 'test_user'),
     ])
-def test_decide_with_fetch_segments(session_override_sdk_key_odp, flag_key, expected_response, expected_status_code, fetch_segments, user_id):
+def test_decide_fetch_qualified_segments(session_override_sdk_key_odp, flag_key, expected_response, expected_status_code, fetch_segments, user_id):
     """
     Test validates:
     Correct response with fetch_segments enabled and disabled.
@@ -110,7 +112,7 @@ def test_decide_with_fetch_segments(session_override_sdk_key_odp, flag_key, expe
     "flag_key, expected_response, expected_status_code", [
         ("flag1", expected_fetch_failed, 500),
     ])
-def test_decide_with_fetch_odp_not_integrated(session_obj, flag_key, expected_response, expected_status_code):
+def test_decide_fetch_qualified_segments_odp_not_integrated(session_obj, flag_key, expected_response, expected_status_code):
     """
     Test validates:
     Correct response when odp not integrated.

--- a/tests/acceptance/test_acceptance/test_odp_decide.py
+++ b/tests/acceptance/test_acceptance/test_odp_decide.py
@@ -1,0 +1,142 @@
+import json
+
+import pytest
+import requests
+
+from tests.acceptance.helpers import ENDPOINT_DECIDE
+from tests.acceptance.helpers import create_and_validate_request_and_response
+from tests.acceptance.helpers import sort_response
+
+expected_fetch_disabled = {
+    "variationKey": "on",
+    "enabled": True,
+    "ruleKey": "flag1_targeted_delivery",
+    "flagKey": "flag1",
+    "userContext": {
+        "userId": "fs-id-1",
+        "attributes": {}
+    },
+    "reasons": ['an error occurred while evaluating nested tree for audience ID "22725221898"',
+                'Audiences for experiment flag1_experiment collectively evaluated to false.',
+                'User "fs-id-1" does not meet conditions to be in experiment "flag1_experiment".',
+                'Audiences for experiment flag1_targeted_delivery collectively evaluated to true.']
+}
+
+expected_no_segments_fetched = {
+    "variationKey": "on",
+    "enabled": True,
+    "ruleKey": "flag1_targeted_delivery",
+    "flagKey": "flag1",
+    "userContext": {
+        "userId": "test_user",
+        "attributes": {}
+    },
+    "reasons": ['an error occurred while evaluating nested tree for audience ID "22725221898"',
+                'Audiences for experiment flag1_experiment collectively evaluated to false.',
+                'User "test_user" does not meet conditions to be in experiment "flag1_experiment".',
+                'Audiences for experiment flag1_targeted_delivery collectively evaluated to true.']
+}
+
+expected_fetch_enabled = {
+    "variationKey": "variation_a",
+    "enabled": True,
+    "ruleKey": "flag1_experiment",
+    "flagKey": "flag1",
+    "userContext": {
+        "userId": "fs-id-1",
+        "attributes": {}
+    },
+    "reasons": ["Audiences for experiment flag1_experiment collectively evaluated to true."]
+}
+
+expected_fetch_enabled_default_rollout = {
+    "variationKey": "off",
+    "enabled": False,
+    "ruleKey": "default-rollout-34903-22583870382",
+    "flagKey": "flag2",
+    "userContext": {
+        "userId": "fs-id-1",
+        "attributes": {}
+    },
+    "reasons": ['Audiences for experiment default-rollout-34903-22583870382 collectively evaluated to true.',
+                'User "fs-id-1" meets conditions for targeting rule "Everyone Else".']
+}
+
+expected_fetch_failed = {
+    'error': 'failed to fetch qualified segments'
+}
+
+
+@pytest.mark.parametrize(
+    "flag_key, expected_response, expected_status_code, fetch_segments, user_id", [
+        ("flag1", expected_fetch_disabled, 200, False, 'fs-id-1'),
+        ("flag1", expected_fetch_enabled, 200, True, 'fs-id-1'),
+        ("flag2", expected_fetch_enabled_default_rollout, 200, True, 'fs-id-1'),
+        ("flag1", expected_no_segments_fetched, 200, True, 'test_user'),
+    ])
+def test_decide_with_fetch_segments(session_override_sdk_key_odp, flag_key, expected_response, expected_status_code, fetch_segments, user_id):
+    """
+    Test validates:
+    Correct response with fetch_segments enabled and disabled.
+    ...
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    :param flag_key:
+    :param expected_response:
+    :param expected_status_code:
+    :param fetch_segments:
+    :param user_id:
+    """
+
+    payload = {
+        "userId": user_id,
+        "decideOptions": [
+            "ENABLED_FLAGS_ONLY",
+            "INCLUDE_REASONS"
+        ],
+        "userAttributes": {},
+        "fetchSegments": fetch_segments,
+    }
+
+    params = {"keys": flag_key}
+    resp = create_and_validate_request_and_response(ENDPOINT_DECIDE, "post", session_override_sdk_key_odp, payload=json.dumps(payload),
+                                                    params=params)
+
+    assert json.loads(json.dumps(expected_response)) == resp.json()
+    assert resp.status_code == expected_status_code, resp.text
+    resp.raise_for_status()
+
+
+@pytest.mark.parametrize(
+    "flag_key, expected_response, expected_status_code", [
+        ("flag1", expected_fetch_failed, 500),
+    ])
+def test_decide_with_fetch_odp_not_integrated(session_obj, flag_key, expected_response, expected_status_code):
+    """
+    Test validates:
+    Correct response when odp not integrated.
+    ...
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    :param flag_key:
+    :param expected_response:
+    :param expected_status_code:
+    """
+
+    payload = {
+        "userId": "fs-id-1",
+        "decideOptions": [
+            "ENABLED_FLAGS_ONLY",
+            "INCLUDE_REASONS"
+        ],
+        "userAttributes": {},
+        "fetchSegments": True,
+    }
+
+    params = {"keys": flag_key}
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        resp = create_and_validate_request_and_response(ENDPOINT_DECIDE, "post", session_obj, payload=json.dumps(payload),
+                                                        params=params)
+
+        assert json.loads(json.dumps(expected_response)) == resp.json()
+        assert resp.status_code == expected_status_code, resp.text
+        resp.raise_for_status()

--- a/tests/acceptance/test_acceptance/test_send_odp_event.py
+++ b/tests/acceptance/test_acceptance/test_send_odp_event.py
@@ -1,0 +1,210 @@
+import json
+
+import pytest
+import requests
+
+from tests.acceptance.helpers import ENDPOINT_SEND_ODP_EVENT
+from tests.acceptance.helpers import create_and_validate_request_and_response
+
+expected_odp_not_integrated = {
+    'error': 'ODP is not integrated'
+}
+
+expected_missing_identifiers = {
+    'error': 'missing or empty "identifiers" in request payload'
+}
+
+expected_invalid_data = {
+    'error': 'ODP data is not valid'
+}
+
+expected_missing_action = {
+    'error': 'missing "action" in request payload'
+}
+
+expected_request_error = {
+    'error': 'error parsing request body'
+}
+
+expected_successful_odp_event = {
+    "success": True
+}
+
+
+@pytest.mark.parametrize(
+    "expected_response, expected_status_code", [
+        (expected_odp_not_integrated, 500)
+    ])
+def test_odp_not_integrated(session_obj, expected_response, expected_status_code):
+    """
+    Test validates:
+    Correct response when valid parameters are provided.
+    ...
+    :param session_obj:
+    :param expected_response:
+    :param expected_status_code:
+    """
+
+    payload = {
+        "type": "test_type",
+        "data": {
+            "idempotence_id": "abc-1234",
+            "data_source_type": "agent",
+        },
+        "identifiers": {"user_id": "test_user_1"},
+        "action": "test_action",
+    }
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        resp = create_and_validate_request_and_response(ENDPOINT_SEND_ODP_EVENT, "post", session_obj, payload=json.dumps(payload),
+                                                        params={})
+
+        assert json.loads(json.dumps(expected_response)) == resp.json()
+        assert resp.status_code == expected_status_code
+        assert resp.text == '{"error":"ODP is not integrated"}\n'
+        resp.raise_for_status()
+
+
+@pytest.mark.parametrize(
+    "expected_response, expected_status_code", [
+        (expected_successful_odp_event, 200)
+    ])
+def test_send_odp_event_valid_payload(session_override_sdk_key_odp, expected_response, expected_status_code):
+    """
+    Test validates:
+    Correct response when valid parameters are provided.
+    ...
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    :param expected_response:
+    :param expected_status_code:
+    """
+
+    payload = {
+        "type": "test_type",
+        "data": {
+            "idempotence_id": "abc-1234",
+            "data_source_type": "agent",
+        },
+        "identifiers": {"user_id": "test_user_1"},
+        "action": "test_action",
+    }
+
+    resp = create_and_validate_request_and_response(ENDPOINT_SEND_ODP_EVENT, "post", session_override_sdk_key_odp, payload=json.dumps(payload),
+                                                    params={})
+
+    assert json.loads(json.dumps(expected_response)) == resp.json()
+    assert resp.status_code == expected_status_code, resp.text
+    resp.raise_for_status()
+
+
+@pytest.mark.parametrize(
+    "identifiers, action, expected_response, expected_status_code, expected_error, bypass_validation_request, bypass_validation_response", [
+        ({}, "test_action", expected_missing_identifiers, 400,
+         '{"error":"missing or empty \\"identifiers\\" in request payload"}\n', False, False),
+        ("", "test_action", expected_request_error, 400,
+         '{"error":"error parsing request body"}\n', True, True),
+        ({"user_id": "test_user_1"}, "", expected_missing_action,
+         400, '{"error":"missing \\"action\\" in request payload"}\n', False, False)
+    ])
+def test_send_odp_event_invalid_parameters(session_override_sdk_key_odp, identifiers, action, expected_response, expected_status_code, expected_error, bypass_validation_request,
+                                           bypass_validation_response):
+    """
+    Test validates:
+    Returns error when empty identifiers or action is provided.
+    ...
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    :param identifiers:
+    :param action:
+    :param expected_response:
+    :param expected_status_code:
+    :param expected_error
+    """
+
+    payload = {
+        "type": "test_type",
+        "data": {
+            "idempotence_id": "abc-1234",
+            "data_source_type": "agent",
+        },
+        "identifiers": identifiers,
+        "action": action,
+    }
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        resp = create_and_validate_request_and_response(ENDPOINT_SEND_ODP_EVENT, "post", session_override_sdk_key_odp, bypass_validation_request,
+                                                        bypass_validation_response, payload=json.dumps(
+                                                            payload),
+                                                        params={})
+
+        assert json.loads(json.dumps(expected_response)) == resp.json()
+        assert resp.status_code == expected_status_code
+        assert resp.text == expected_error
+        resp.raise_for_status()
+
+
+@pytest.mark.parametrize(
+    "expected_response, expected_status_code, expected_error, bypass_validation_request, bypass_validation_response", [
+        (expected_invalid_data, 500,
+         '{"error":"ODP data is not valid"}\n', True, True)
+    ])
+def test_send_odp_event_invalid_data(session_override_sdk_key_odp, expected_response, expected_status_code, expected_error, bypass_validation_request,
+                                     bypass_validation_response):
+    """
+    Test validates:
+    Returns error when invalid attributes are provided under data.
+    ...
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    :param expected_response:
+    :param expected_status_code:
+    :param expected_error
+    """
+
+    payload = {
+        "type": "test_type",
+        "data": {
+            "idempotence_id": {"invalid": "kv"},
+            "data_source_type": [],
+        },
+        "identifiers": {"user_id": "test_user_1"},
+        "action": "test_action",
+    }
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        resp = create_and_validate_request_and_response(ENDPOINT_SEND_ODP_EVENT, "post",
+                                                        session_override_sdk_key_odp,
+                                                        bypass_validation_request,
+                                                        bypass_validation_response,
+                                                        payload=json.dumps(
+                                                            payload),
+                                                        params={})
+
+        assert json.loads(json.dumps(expected_response)) == resp.json()
+        assert resp.status_code == expected_status_code
+        assert resp.text == expected_error
+        resp.raise_for_status()
+
+
+def test_send_odp_event_403(session_override_sdk_key):
+    """
+    Test that 403 Forbidden is returned. We use invalid SDK key to trigger 403.
+    :param session_override_sdk_key: sdk key to override the session using invalid sdk key
+    """
+    payload = {
+        "type": "test_type",
+        "data": {
+            "idempotence_id": "abc-1234",
+            "data_source_type": "agent",
+        },
+        "identifiers": {"user_id": "test_user_1"},
+        "action": "test_action",
+    }
+
+    with pytest.raises(requests.exceptions.HTTPError):
+        resp = create_and_validate_request_and_response(ENDPOINT_SEND_ODP_EVENT, 'post', session_override_sdk_key,
+                                                        payload=json.dumps(payload), params={})
+
+        assert resp.status_code == 403
+        assert resp.json()['error'] == 'unable to fetch fresh datafile (consider ' \
+            'rechecking SDK key), status code: 403 Forbidden'
+
+        resp.raise_for_status()


### PR DESCRIPTION
## Summary
- Adds acceptance tests or send-odp-event api.
- Fixes a crash caused by nil logger being passed with odp components.

## Issues
- [FSSDK-8839](https://jira.sso.episerver.net/browse/FSSDK-8839)

## Tests
- All tests should pass
