### PR TITLE
[FSSDK-9026](WIP): Adds tests for redis cache.

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -106,6 +106,10 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: 3.9
+    - name: Start Redis
+      uses: supercharge/redis-github-action@1.5.0
+      with:
+        redis-version: 4
     - name: acceptance test
       run: |
         make -e setup build

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ help: ## help
 test-acceptance:
 	export OPTIMIZELY_SERVER_BATCHREQUESTS_OPERATIONSLIMIT='3' && \
 	export OPTIMIZELY_CLIENT_USERPROFILESERVICE='{"default":"in-memory","services":{"in-memory":{"storagestrategy":"fifo"}}}' && \
+	export OPTIMIZELY_CLIENT_ODP_SEGMENTSCACHE='{"default":"redis","services":{"redis":{"host":"localhost:6379","password":"","timeout":"0s","database": 0}}}' && \
 	make clean && \
 	make setup && \
 	make run & \

--- a/plugins/odpcache/services/redis_cache.go
+++ b/plugins/odpcache/services/redis_cache.go
@@ -57,13 +57,14 @@ func (r *RedisCache) Lookup(key string) (segments interface{}) {
 		return
 	}
 
+	var fSegments []string
 	// Check if result was unmarshalled successfully
-	err := json.Unmarshal([]byte(result), &segments)
+	err := json.Unmarshal([]byte(result), &fSegments)
 	if err != nil {
 		log.Error().Msg(err.Error())
 		return
 	}
-	return segments
+	return fSegments
 }
 
 // Save is used to save segments

--- a/tests/acceptance/requirements.txt
+++ b/tests/acceptance/requirements.txt
@@ -3,3 +3,4 @@ pytest-clarity==1.0.1
 requests==2.27.1
 openapi_core==0.14.2
 openapi_spec_validator==0.4.0
+redis==4.2.2

--- a/tests/acceptance/test_acceptance/test_odp_redis.py
+++ b/tests/acceptance/test_acceptance/test_odp_redis.py
@@ -1,0 +1,148 @@
+import json
+
+import pytest
+import requests
+import redis
+import time
+
+from tests.acceptance.helpers import ENDPOINT_DECIDE
+from tests.acceptance.helpers import create_and_validate_request_and_response
+from tests.acceptance.helpers import sort_response
+
+expected_redis_save = {
+    "variationKey": "variation_b",
+    "enabled": True,
+    "ruleKey": "ab_experiment",
+    "flagKey": "flag1",
+    "userContext": {
+        "userId": "fs-id-1",
+        "attributes": {}
+    },
+    "reasons": ["Audiences for experiment ab_experiment collectively evaluated to true."]
+}
+
+expected_redis_lookup = {
+    "variationKey": "variation_b",
+    "enabled": True,
+    "ruleKey": "ab_experiment",
+    "flagKey": "flag1",
+    "userContext": {
+        "userId": "fs-id-2",
+        "attributes": {}
+    },
+    "reasons": ["Audiences for experiment ab_experiment collectively evaluated to true."]
+}
+
+expected_redis_reset = {
+    "variationKey": "variation_a",
+    "enabled": True,
+    "ruleKey": "ab_experiment",
+    "flagKey": "flag1",
+    "userContext": {
+        "userId": "fs-id-3",
+        "attributes": {}
+    },
+    "reasons": ["Audiences for experiment ab_experiment collectively evaluated to true."]
+}
+
+def test_redis_save(session_override_sdk_key_odp):
+    """
+    Test that first fetch call saves segments in redis successfuly.
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    """
+    
+    expected_segments = ["atsbugbashsegmentdob", "atsbugbashsegmentgender"]
+    uId = "fs_user_id-$-fs-id-1"
+    r = redis.Redis(host='localhost', port=6379, db=0)
+
+    payload = {
+        "userId": "fs-id-1",
+        "decideOptions": [
+            "ENABLED_FLAGS_ONLY",
+            "INCLUDE_REASONS"
+        ],
+        "userAttributes": {},
+        "fetchSegments": True,
+    }
+
+    params = {"keys": "flag1"}
+    resp = create_and_validate_request_and_response(ENDPOINT_DECIDE, "post", session_override_sdk_key_odp, payload=json.dumps(payload),
+                                                    params=params)
+
+    # Check saved segments
+    assert json.loads(json.dumps(expected_segments)) == json.loads(r.get(uId))
+        
+    assert json.loads(json.dumps(expected_redis_save)) == resp.json()
+    assert resp.status_code == 200, resp.text
+    resp.raise_for_status()
+
+
+def test_redis_lookup(session_override_sdk_key_odp):
+    """
+    Test that saved segments in redis are used successfuly by segment manager using lookup.
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    """
+    
+    expected_segments = ["atsbugbashsegmentdob", "atsbugbashsegmentgender"]
+    uId = "fs_user_id-$-fs-id-2"
+    r = redis.Redis(host='localhost', port=6379, db=0)
+    r.set(uId, json.dumps(expected_segments))
+
+    payload = {
+        "userId": "fs-id-2",
+        "decideOptions": [
+            "ENABLED_FLAGS_ONLY",
+            "INCLUDE_REASONS"
+        ],
+        "userAttributes": {},
+        "fetchSegments": True,
+    }
+
+    params = {"keys": "flag1"}
+    resp = create_and_validate_request_and_response(ENDPOINT_DECIDE, "post", session_override_sdk_key_odp, payload=json.dumps(payload),
+                                                    params=params)
+
+    # Check saved segments
+    assert json.loads(json.dumps(expected_segments)) == json.loads(r.get(uId))
+        
+    assert json.loads(json.dumps(expected_redis_lookup)) == resp.json()
+    assert resp.status_code == 200, resp.text
+    resp.raise_for_status()
+
+
+def test_redis_reset(session_override_sdk_key_odp):
+    """
+    Test that reset option resets segments in redis.
+    :param session_override_sdk_key_odp: sdk key to override the session using odp key
+    """
+    
+    expected_segments_after_reset = ["atsbugbashsegmentdob", "atsbugbashsegmentgender"]
+    uId = "fs_user_id-$-fs-id-3"
+    r = redis.Redis(host='localhost', port=6379, db=0)
+
+    # Manually add invalid segments for fs-id-3 in redis
+    r.set(uId, json.dumps(["invalid_segments"]))
+    # Check invalid segments were saved
+    assert json.loads(json.dumps(["invalid_segments"])) == json.loads(r.get(uId))
+
+    payload = {
+        "userId": "fs-id-3",
+        "decideOptions": [
+            "ENABLED_FLAGS_ONLY",
+            "INCLUDE_REASONS"
+        ],
+        "userAttributes": {},
+        "fetchSegments": True,
+        "fetchSegmentsOptions": ["RESET_CACHE"],
+    }
+
+    params = {"keys": "flag1"}
+    resp = create_and_validate_request_and_response(ENDPOINT_DECIDE, "post", session_override_sdk_key_odp, payload=json.dumps(payload),
+                                                    params=params)
+
+    # Check old segments were removed and newly fetched were saved
+    assert json.loads(json.dumps(expected_segments_after_reset)) == json.loads(r.get(uId))
+        
+    assert json.loads(json.dumps(expected_redis_reset)) == resp.json()
+    assert resp.status_code == 200, resp.text
+    resp.raise_for_status()


### PR DESCRIPTION
## Summary
- Adds acceptance tests for redis odp cache.

## Issues
- [FSSDK-9026](https://jira.sso.episerver.net/browse/FSSDK-9026)

## Tests
- All tests should pass
