### PR TITLE
[FSSDK-9003] fix(github-actions): Replace deprecated set-output command with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -136,10 +136,10 @@ jobs:
       id: get_version
       run: |
         git fetch --tags --force
-        echo ::set-output name=VERSION::$(git describe --abbrev=0 --tags | tr -d '^v')
+        echo "VERSION=$(git describe --abbrev=0 --tags | tr -d '^v')" >> $GITHUB_OUTPUT
     - name: Get current workspace path
       id: get_workspace
-      run: echo ::set-output name=WORKSPACE::${GITHUB_WORKSPACE}
+      run: echo "WORKSPACE=${GITHUB_WORKSPACE}" >> $GITHUB_OUTPUT
     - name: set the env
       run: |
         echo "APP_VERSION=${{ steps.get_version.outputs.VERSION }}" >> $GITHUB_ENV
@@ -173,10 +173,10 @@ jobs:
         ref: 'master'
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF_NAME}
+      run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
     - name: Get current workspace path
       id: get_workspace
-      run: echo ::set-output name=WORKSPACE::${GITHUB_WORKSPACE}
+      run: echo "WORKSPACE=${GITHUB_WORKSPACE}" >> $GITHUB_OUTPUT
     - name: set the env
       run: |
         TAG=${{ steps.get_version.outputs.VERSION }}
@@ -244,7 +244,7 @@ jobs:
         ref: 'master'
     - name: Get the version
       id: get_version
-      run: echo ::set-output name=VERSION::${GITHUB_REF_NAME}
+      run: echo "VERSION=${GITHUB_REF_NAME}" >> $GITHUB_OUTPUT
     - name: set the env
       run: |
         TAG=${{ steps.get_version.outputs.VERSION }}


### PR DESCRIPTION
## Summary
- Replace deprecated set-output command with GITHUB_OUTPUT. Details: [Ref](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/)

## Ticket

- [FSSDK-9003](https://jira.sso.episerver.net/browse/FSSDK-9003)
