### PR TITLE
fix(github-actions): fix sourceclear github actions failure

### DIFF
--- a/.github/workflows/agent.yml
+++ b/.github/workflows/agent.yml
@@ -72,7 +72,9 @@ jobs:
     - name: sourceclear
       env:
         SRCCLR_API_TOKEN: ${{ secrets.SRCCLR_API_TOKEN }}
-      run: curl -sSL https://download.sourceclear.com/ci.sh | bash -s – scan
+      run: |
+        make -e setup build
+        curl -sSL https://download.sourceclear.com/ci.sh | bash -s – scan
     - name: run
       run: |
         make -e setup build

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -28,7 +28,6 @@ import (
 	"github.com/optimizely/agent/pkg/metrics"
 	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely"
-	_ "github.com/optimizely/agent/statik" // Required to serve openapi.yaml
 
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"

--- a/pkg/routers/api.go
+++ b/pkg/routers/api.go
@@ -28,6 +28,7 @@ import (
 	"github.com/optimizely/agent/pkg/metrics"
 	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/agent/pkg/optimizely"
+	_ "github.com/optimizely/agent/statik" // Required to serve openapi.yaml
 
 	"github.com/go-chi/chi/v5"
 	chimw "github.com/go-chi/chi/v5/middleware"


### PR DESCRIPTION
## Summary
- There is an unreachable forced [import](https://github.com/optimizely/agent/blob/master/pkg/routers/api.go#L31) which causes failure in github action in sourceclear part. For this sourceclear failed to list dependencies using `go list -deps -json all` command.

- The local statik package is ignored in the .gitignore & only available after build. Without building the project `go mod tidy` command couldn't find the local statik package.

