### PR TITLE
fix: fix trace middleware http writer

### DIFF
--- a/pkg/middleware/trace.go
+++ b/pkg/middleware/trace.go
@@ -98,11 +98,12 @@ func AddTracing(conf config.TracingConfig, tracerName, spanName string) func(htt
 				attribute.String(OptlySDKHeader, r.Header.Get(OptlySDKHeader)),
 			)
 
-			next.ServeHTTP(w, r.WithContext(ctx))
+			respWriter := middleware.NewWrapResponseWriter(w, r.ProtoMajor)
 
-			statusCode := middleware.NewWrapResponseWriter(w, r.ProtoMajor).Status()
+			next.ServeHTTP(respWriter, r.WithContext(ctx))
+
 			span.SetAttributes(
-				semconv.HTTPStatusCodeKey.Int(statusCode),
+				semconv.HTTPStatusCodeKey.Int(respWriter.Status()),
 			)
 		}
 		return http.HandlerFunc(fn)

--- a/tests/acceptance/test_acceptance/test_odp_redis.py
+++ b/tests/acceptance/test_acceptance/test_odp_redis.py
@@ -52,6 +52,7 @@ def test_redis_save(session_override_sdk_key_odp):
     """
     
     expected_segments = ["atsbugbashsegmenthaspurchased", "atsbugbashsegmentdob"]
+    expected_segments_rev = ["atsbugbashsegmentdob", "atsbugbashsegmenthaspurchased"]
     uId = "fs_user_id-$-matjaz-user-1"
     r = redis.Redis(host='localhost', port=6379, db=0)
     # clean redis before testing since several tests use same user_id
@@ -72,7 +73,7 @@ def test_redis_save(session_override_sdk_key_odp):
                                                     params=params)
 
     # Check saved segments
-    assert json.loads(json.dumps(expected_segments)) == json.loads(r.get(uId))
+    assert json.loads(json.dumps(expected_segments)) == json.loads(r.get(uId)) or json.loads(json.dumps(expected_segments_rev)) == json.loads(r.get(uId))
         
     assert json.loads(json.dumps(expected_redis_save)) == resp.json()
     assert resp.status_code == 200, resp.text


### PR DESCRIPTION
## Summary
- use http response writer from chi router to avoid error case like notification api expects this writer to implement flusher interface. Using http response writer from chi router eliminate any such errors.

- fixed one continuously failing acceptance test

