### PR TITLE
[FSSDK-9840] chore: prepare for 3.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - December 13, 2023
+
+### New Features
+
+- Added support for including `traceId` and `spanId` into the logs. ([#407](https://github.com/optimizely/agent/pull/407))
+
 ## [3.1.0] - November 3, 2023
 
 ### New Features


### PR DESCRIPTION
## Summary
- updated changelog for release 3.2.0

## Ticket
- [FSSDK-9840](https://jira.sso.episerver.net/browse/FSSDK-9840)
