### PR TITLE
[FSSDK-10553] add IsEveryoneElseVariation marker in decide API

### DIFF
--- a/pkg/handlers/decide.go
+++ b/pkg/handlers/decide.go
@@ -123,7 +123,7 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 		key := keys[0]
 		logger.Debug().Str("featureKey", key).Msg("fetching feature decision")
 		d := optimizelyUserContext.Decide(key, decideOptions)
-		decideOut := DecideOut{d, d.Variables.ToMap(), IsEveryoneElseVariation(featureMap[d.FlagKey].DeliveryRules, d.RuleKey)}
+		decideOut := DecideOut{d, d.Variables.ToMap(), isEveryoneElseVariation(featureMap[d.FlagKey].DeliveryRules, d.RuleKey)}
 		render.JSON(w, r, decideOut)
 		return
 	default:
@@ -133,7 +133,7 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 
 	decideOuts := []DecideOut{}
 	for _, d := range decides {
-		decideOut := DecideOut{d, d.Variables.ToMap(), IsEveryoneElseVariation(featureMap[d.FlagKey].DeliveryRules, d.RuleKey)}
+		decideOut := DecideOut{d, d.Variables.ToMap(), isEveryoneElseVariation(featureMap[d.FlagKey].DeliveryRules, d.RuleKey)}
 		decideOuts = append(decideOuts, decideOut)
 		logger.Debug().Msgf("Feature %q is enabled for user %s? %t", d.FlagKey, d.UserContext.UserID, d.Enabled)
 	}
@@ -154,7 +154,7 @@ func getUserContextWithOptions(r *http.Request) (DecideBody, error) {
 	return body, nil
 }
 
-func IsEveryoneElseVariation(rules []config.OptimizelyExperiment, ruleKey string) bool {
+func isEveryoneElseVariation(rules []config.OptimizelyExperiment, ruleKey string) bool {
 	for _, r := range rules {
 		if r.Key == ruleKey {
 			return r.Key == r.ID && strings.HasPrefix(r.Key, DefaultRolloutPrefix)

--- a/pkg/handlers/decide.go
+++ b/pkg/handlers/decide.go
@@ -32,7 +32,7 @@ import (
 	"github.com/optimizely/go-sdk/v2/pkg/odp/segment"
 )
 
-const DefaultRolloutPrefix = "default-rollout-"
+const DefaultRolloutPrefix = "default-"
 
 // DecideBody defines the request body for decide API
 type DecideBody struct {
@@ -102,15 +102,10 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 		keys = r.Form["keys"]
 	}
 
+	featureMap := make(map[string]config.OptimizelyFeature)
 	cfg := optlyClient.GetOptimizelyConfig()
-	if cfg == nil {
-		RenderError(errors.New("optimizely config not found"), http.StatusInternalServerError, w, r)
-		return
-	}
-	featureMap := cfg.FeaturesMap
-	if featureMap == nil {
-		RenderError(errors.New("features not found in config"), http.StatusInternalServerError, w, r)
-		return
+	if cfg != nil {
+		featureMap = cfg.FeaturesMap
 	}
 
 	var decides map[string]client.OptimizelyDecision

--- a/pkg/handlers/decide.go
+++ b/pkg/handlers/decide.go
@@ -20,15 +20,19 @@ package handlers
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/go-chi/render"
 
 	"github.com/optimizely/agent/pkg/middleware"
 	"github.com/optimizely/go-sdk/v2/pkg/client"
+	"github.com/optimizely/go-sdk/v2/pkg/config"
 	"github.com/optimizely/go-sdk/v2/pkg/decide"
 	"github.com/optimizely/go-sdk/v2/pkg/decision"
 	"github.com/optimizely/go-sdk/v2/pkg/odp/segment"
 )
+
+const DefaultRolloutPrefix = "default-rollout-"
 
 // DecideBody defines the request body for decide API
 type DecideBody struct {
@@ -50,7 +54,8 @@ type ForcedDecision struct {
 // DecideOut defines the response
 type DecideOut struct {
 	client.OptimizelyDecision
-	Variables map[string]interface{} `json:"variables,omitempty"`
+	Variables               map[string]interface{} `json:"variables,omitempty"`
+	IsEveryoneElseVariation bool                   `json:"isEveryoneElseVariation"`
 }
 
 // Decide makes feature decisions for the selected query parameters
@@ -97,6 +102,17 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 		keys = r.Form["keys"]
 	}
 
+	cfg := optlyClient.GetOptimizelyConfig()
+	if cfg == nil {
+		RenderError(errors.New("optimizely config not found"), http.StatusInternalServerError, w, r)
+		return
+	}
+	featureMap := cfg.FeaturesMap
+	if featureMap == nil {
+		RenderError(errors.New("features not found in config"), http.StatusInternalServerError, w, r)
+		return
+	}
+
 	var decides map[string]client.OptimizelyDecision
 	switch len(keys) {
 	case 0:
@@ -107,7 +123,7 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 		key := keys[0]
 		logger.Debug().Str("featureKey", key).Msg("fetching feature decision")
 		d := optimizelyUserContext.Decide(key, decideOptions)
-		decideOut := DecideOut{d, d.Variables.ToMap()}
+		decideOut := DecideOut{d, d.Variables.ToMap(), IsEveryoneElseVariation(featureMap[d.FlagKey].DeliveryRules, d.RuleKey)}
 		render.JSON(w, r, decideOut)
 		return
 	default:
@@ -117,7 +133,7 @@ func Decide(w http.ResponseWriter, r *http.Request) {
 
 	decideOuts := []DecideOut{}
 	for _, d := range decides {
-		decideOut := DecideOut{d, d.Variables.ToMap()}
+		decideOut := DecideOut{d, d.Variables.ToMap(), IsEveryoneElseVariation(featureMap[d.FlagKey].DeliveryRules, d.RuleKey)}
 		decideOuts = append(decideOuts, decideOut)
 		logger.Debug().Msgf("Feature %q is enabled for user %s? %t", d.FlagKey, d.UserContext.UserID, d.Enabled)
 	}
@@ -136,4 +152,13 @@ func getUserContextWithOptions(r *http.Request) (DecideBody, error) {
 	}
 
 	return body, nil
+}
+
+func IsEveryoneElseVariation(rules []config.OptimizelyExperiment, ruleKey string) bool {
+	for _, r := range rules {
+		if r.Key == ruleKey {
+			return r.Key == r.ID && strings.HasPrefix(r.Key, DefaultRolloutPrefix)
+		}
+	}
+	return false
 }

--- a/pkg/handlers/decide_test.go
+++ b/pkg/handlers/decide_test.go
@@ -124,17 +124,21 @@ func (suite *DecideTestSuite) TestDecideWithFeatureTest() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err := json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "2",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "2",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -152,17 +156,21 @@ func (suite *DecideTestSuite) TestTrackWithFeatureRollout() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err := json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "3",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "3",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -206,17 +214,21 @@ func (suite *DecideTestSuite) TestInvalidForcedDecisions() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err = json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "2",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "2",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -265,17 +277,21 @@ func (suite *DecideTestSuite) TestForcedDecisionWithFeatureTest() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err = json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "4",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "4",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -323,17 +339,21 @@ func (suite *DecideTestSuite) TestForcedDecisionFeatureRollout() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err = json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "4",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "4",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -369,17 +389,21 @@ func (suite *DecideTestSuite) TestForcedDecisionWithInvalidVariationKey() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err = json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "3",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "3",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -416,17 +440,21 @@ func (suite *DecideTestSuite) TestForcedDecisionWithEmptyRuleKey() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err = json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "",
-		Enabled:      true,
-		VariationKey: "4",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "",
+			Enabled:      true,
+			VariationKey: "4",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -444,18 +472,23 @@ func (suite *DecideTestSuite) TestTrackWithFeatureTest() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err := json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "one",
-		RuleKey:      "1",
-		Enabled:      true,
-		VariationKey: "2",
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "one",
+			RuleKey:      "1",
+			Enabled:      true,
+			VariationKey: "2",
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
+
 	suite.Equal(expected, actual)
 
 	events := suite.tc.GetProcessedEvents()
@@ -473,17 +506,21 @@ func (suite *DecideTestSuite) TestDecideMissingFlag() {
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err := json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
-		FlagKey:      "feature-missing",
-		RuleKey:      "",
-		Enabled:      false,
-		VariationKey: "",
-		Reasons:      []string{"No flag was found for key \"feature-missing\"."},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: "testUser", Attributes: map[string]interface{}{}},
+			FlagKey:      "feature-missing",
+			RuleKey:      "",
+			Enabled:      false,
+			VariationKey: "",
+			Reasons:      []string{"No flag was found for key \"feature-missing\"."},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(0, len(suite.tc.GetProcessedEvents()))
@@ -514,7 +551,8 @@ func (suite *DecideTestSuite) TestDecideMultipleFlags() {
 				VariationKey: "3",
 				Reasons:      []string{},
 			},
-			Variables: nil,
+			Variables:               nil,
+			IsEveryoneElseVariation: false,
 		},
 		{
 			OptimizelyDecision: client.OptimizelyDecision{
@@ -525,7 +563,8 @@ func (suite *DecideTestSuite) TestDecideMultipleFlags() {
 				VariationKey: "6",
 				Reasons:      []string{},
 			},
-			Variables: nil,
+			Variables:               nil,
+			IsEveryoneElseVariation: false,
 		},
 	}
 
@@ -573,7 +612,8 @@ func (suite *DecideTestSuite) TestDecideAllFlags() {
 				VariationKey: "3",
 				Reasons:      []string{},
 			},
-			Variables: nil,
+			Variables:               nil,
+			IsEveryoneElseVariation: false,
 		},
 		{
 			OptimizelyDecision: client.OptimizelyDecision{
@@ -584,7 +624,8 @@ func (suite *DecideTestSuite) TestDecideAllFlags() {
 				VariationKey: "6",
 				Reasons:      []string{},
 			},
-			Variables: nil,
+			Variables:               nil,
+			IsEveryoneElseVariation: false,
 		},
 		{
 			OptimizelyDecision: client.OptimizelyDecision{
@@ -595,7 +636,8 @@ func (suite *DecideTestSuite) TestDecideAllFlags() {
 				VariationKey: "13",
 				Reasons:      []string{},
 			},
-			Variables: map[string]interface{}{"strvar": "abc_notdef"},
+			Variables:               map[string]interface{}{"strvar": "abc_notdef"},
+			IsEveryoneElseVariation: false,
 		},
 	}
 
@@ -703,17 +745,21 @@ func DecideWithFetchSegments(suite *DecideTestSuite, userID string, fetchSegment
 	suite.Equal(http.StatusOK, rec.Code)
 
 	// Unmarshal response
-	var actual client.OptimizelyDecision
+	var actual DecideOut
 	err = json.Unmarshal(rec.Body.Bytes(), &actual)
 	suite.NoError(err)
 
-	expected := client.OptimizelyDecision{
-		UserContext:  client.OptimizelyUserContext{UserID: userID, Attributes: map[string]interface{}{}},
-		FlagKey:      featureKey,
-		RuleKey:      experimentKey,
-		Enabled:      true,
-		VariationKey: variationKey,
-		Reasons:      []string{},
+	expected := DecideOut{
+		OptimizelyDecision: client.OptimizelyDecision{
+			UserContext:  client.OptimizelyUserContext{UserID: userID, Attributes: map[string]interface{}{}},
+			FlagKey:      featureKey,
+			RuleKey:      experimentKey,
+			Enabled:      true,
+			VariationKey: variationKey,
+			Reasons:      []string{},
+		},
+		Variables:               nil,
+		IsEveryoneElseVariation: false,
 	}
 
 	suite.Equal(expected, actual)

--- a/tests/acceptance/test_acceptance/test_decide.py
+++ b/tests/acceptance/test_acceptance/test_decide.py
@@ -12,7 +12,7 @@ expected_forced_decision_without_rule_key = {
     "enabled": True,
     "ruleKey": "",
     "flagKey": "feature_2",
-    "isEveryoneElseVariation": false,
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -27,7 +27,7 @@ expected_forced_decision_with_rule_key = {
     "enabled": True,
     "ruleKey": "feature_2_test",
     "flagKey": "feature_2",
-    "isEveryoneElseVariation": false,
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz",
         "attributes": {

--- a/tests/acceptance/test_acceptance/test_decide.py
+++ b/tests/acceptance/test_acceptance/test_decide.py
@@ -12,7 +12,7 @@ expected_forced_decision_without_rule_key = {
     "enabled": True,
     "ruleKey": "",
     "flagKey": "feature_2",
-    "isEveryoneElseVariation": False,
+    "isEveryoneElseVariation": false,
     "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -27,7 +27,7 @@ expected_forced_decision_with_rule_key = {
     "enabled": True,
     "ruleKey": "feature_2_test",
     "flagKey": "feature_2",
-    "isEveryoneElseVariation": False,
+    "isEveryoneElseVariation": false,
     "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -45,7 +45,7 @@ expected_single_flag_key_with_ups = r"""
       "enabled": true,
       "ruleKey": "feature_2_test",
       "flagKey": "feature_2",
-      "isEveryoneElseVariation": False,
+      "isEveryoneElseVariation": false,
       "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -62,7 +62,7 @@ expected_single_flag_key_no_ups = r"""
       "enabled": true,
       "ruleKey": "feature_2_test",
       "flagKey": "feature_2",
-      "isEveryoneElseVariation": False,
+      "isEveryoneElseVariation": false,
       "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -79,7 +79,7 @@ expected_invalid_flag_key = r"""
       "enabled": false,
       "ruleKey": "",
       "flagKey": "invalid_flag_key",
-      "isEveryoneElseVariation": False,
+      "isEveryoneElseVariation": false,
       "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -162,6 +162,7 @@ expected_flag_keys_with_ups = r"""[
     "variationKey": "16925940659",
     "enabled": true,
     "ruleKey": "default-16943340293",
+    "isEveryoneElseVariation": true,
     "flagKey": "feature_4",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": [
@@ -172,6 +173,7 @@ expected_flag_keys_with_ups = r"""[
     "variationKey": "variation_1",
     "enabled": true,
     "ruleKey": "ab_test1",
+    "isEveryoneElseVariation": false,
     "flagKey": "GkbzTurBWXr8EtNGZj2j6e",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": ["User \"matjaz\" was previously bucketed into variation \"variation_1\" of experiment \"ab_test1\"."]},
@@ -179,6 +181,7 @@ expected_flag_keys_with_ups = r"""[
     "variationKey": "variation_1",
     "enabled": true,
     "ruleKey": "feature_2_test",
+    "isEveryoneElseVariation": false,
     "flagKey": "feature_2",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
     "reasons": ["User \"matjaz\" was previously bucketed into variation \"variation_1\" of experiment \"feature_2_test\"."]},
@@ -186,6 +189,7 @@ expected_flag_keys_with_ups = r"""[
     "variationKey": "16927890136",
     "enabled": true,
     "ruleKey": "default-16917103311",
+    "isEveryoneElseVariation": true,
     "flagKey": "feature_5",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
     "reasons": [
@@ -196,6 +200,7 @@ expected_flag_keys_with_ups = r"""[
     "variationKey": "16906801184",
     "enabled": true,
     "ruleKey": "16941022436",
+    "isEveryoneElseVariation": false,
     "flagKey": "feature_1",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
     "reasons": ["Audiences for experiment 16941022436 collectively evaluated to true."],
@@ -208,6 +213,7 @@ expected_flag_key__multiple_parameters_with_ups = r"""[
       "variationKey": "16906801184",
       "enabled": true,
       "ruleKey": "16941022436",
+      "isEveryoneElseVariation": false,
       "flagKey": "feature_1",
         "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": ["Audiences for experiment 16941022436 collectively evaluated to true."],
@@ -216,6 +222,7 @@ expected_flag_key__multiple_parameters_with_ups = r"""[
       "variationKey": "variation_1",
       "enabled": true,
       "ruleKey": "feature_2_test",
+      "isEveryoneElseVariation": false,
       "flagKey": "feature_2",
         "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": ["User \"matjaz\" was previously bucketed into variation \"variation_1\" of experiment \"feature_2_test\"."]},
@@ -223,6 +230,7 @@ expected_flag_key__multiple_parameters_with_ups = r"""[
       "variationKey": "16925940659",
       "enabled": true,
       "ruleKey": "default-16943340293",
+      "isEveryoneElseVariation": true,
       "flagKey": "feature_4",
         "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": [
@@ -233,6 +241,7 @@ expected_flag_key__multiple_parameters_with_ups = r"""[
       "variationKey": "16927890136",
       "enabled": true,
       "ruleKey": "default-16917103311",
+      "isEveryoneElseVariation": true,
       "flagKey": "feature_5",
         "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": [
@@ -247,6 +256,7 @@ expected_flag_keys_no_ups = r"""[
     "variationKey": "16925940659",
     "enabled": true,
     "ruleKey": "16939051724",
+    "isEveryoneElseVariation": false,
     "flagKey": "feature_4",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": ["Audiences for experiment 16939051724 collectively evaluated to true."]},
@@ -254,6 +264,7 @@ expected_flag_keys_no_ups = r"""[
     "variationKey": "variation_1",
     "enabled": true,
     "ruleKey": "ab_test1",
+    "isEveryoneElseVariation": false,
     "flagKey": "GkbzTurBWXr8EtNGZj2j6e",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
       "reasons": ["Audiences for experiment ab_test1 collectively evaluated to true."]},
@@ -261,6 +272,7 @@ expected_flag_keys_no_ups = r"""[
     "variationKey": "variation_1",
     "enabled": true,
     "ruleKey": "feature_2_test",
+    "isEveryoneElseVariation": false,
     "flagKey": "feature_2",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
     "reasons": ["Audiences for experiment feature_2_test collectively evaluated to true."]},
@@ -268,6 +280,7 @@ expected_flag_keys_no_ups = r"""[
     "variationKey": "16927890136",
     "enabled": true,
     "ruleKey": "16932940705",
+    "isEveryoneElseVariation": false,
     "flagKey": "feature_5",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
     "reasons": ["Audiences for experiment 16932940705 collectively evaluated to true."]},
@@ -275,6 +288,7 @@ expected_flag_keys_no_ups = r"""[
     "variationKey": "16906801184",
     "enabled": true,
     "ruleKey": "16941022436",
+    "isEveryoneElseVariation": false,
     "flagKey": "feature_1",
       "userContext": {"userId": "matjaz", "attributes": {"attr_1": "hola"}},
     "reasons": ["Audiences for experiment 16941022436 collectively evaluated to true."],

--- a/tests/acceptance/test_acceptance/test_decide.py
+++ b/tests/acceptance/test_acceptance/test_decide.py
@@ -12,6 +12,7 @@ expected_forced_decision_without_rule_key = {
     "enabled": True,
     "ruleKey": "",
     "flagKey": "feature_2",
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -26,6 +27,7 @@ expected_forced_decision_with_rule_key = {
     "enabled": True,
     "ruleKey": "feature_2_test",
     "flagKey": "feature_2",
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -43,6 +45,7 @@ expected_single_flag_key_with_ups = r"""
       "enabled": true,
       "ruleKey": "feature_2_test",
       "flagKey": "feature_2",
+      "isEveryoneElseVariation": False,
       "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -59,6 +62,7 @@ expected_single_flag_key_no_ups = r"""
       "enabled": true,
       "ruleKey": "feature_2_test",
       "flagKey": "feature_2",
+      "isEveryoneElseVariation": False,
       "userContext": {
         "userId": "matjaz",
         "attributes": {
@@ -75,6 +79,7 @@ expected_invalid_flag_key = r"""
       "enabled": false,
       "ruleKey": "",
       "flagKey": "invalid_flag_key",
+      "isEveryoneElseVariation": False,
       "userContext": {
         "userId": "matjaz",
         "attributes": {

--- a/tests/acceptance/test_acceptance/test_odp_decide.py
+++ b/tests/acceptance/test_acceptance/test_odp_decide.py
@@ -12,7 +12,7 @@ expected_fetch_disabled = {
     "enabled": False,
     "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": True,
+    "isEveryoneElseVariation": true,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -29,7 +29,7 @@ expected_no_segments_fetched = {
     "enabled": False,
     "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": True,
+    "isEveryoneElseVariation": true,
     "userContext": {
         "userId": "test_user",
         "attributes": {}
@@ -46,7 +46,7 @@ expected_fetch_enabled = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": False,
+    "isEveryoneElseVariation": false,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -59,7 +59,7 @@ expected_fetch_enabled_default_rollout = {
     "enabled": False,
     "ruleKey": "default-rollout-52231-23726430538",
     "flagKey": "flag2",
-    "isEveryoneElseVariation": True,
+    "isEveryoneElseVariation": true,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}

--- a/tests/acceptance/test_acceptance/test_odp_decide.py
+++ b/tests/acceptance/test_acceptance/test_odp_decide.py
@@ -12,6 +12,7 @@ expected_fetch_disabled = {
     "enabled": False,
     "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
+    "isEveryoneElseVariation": True,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -28,6 +29,7 @@ expected_no_segments_fetched = {
     "enabled": False,
     "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
+    "isEveryoneElseVariation": True,
     "userContext": {
         "userId": "test_user",
         "attributes": {}
@@ -44,6 +46,7 @@ expected_fetch_enabled = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -56,6 +59,7 @@ expected_fetch_enabled_default_rollout = {
     "enabled": False,
     "ruleKey": "default-rollout-52231-23726430538",
     "flagKey": "flag2",
+    "isEveryoneElseVariation": True,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}

--- a/tests/acceptance/test_acceptance/test_odp_decide.py
+++ b/tests/acceptance/test_acceptance/test_odp_decide.py
@@ -12,7 +12,7 @@ expected_fetch_disabled = {
     "enabled": False,
     "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": true,
+    "isEveryoneElseVariation": True,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -29,7 +29,7 @@ expected_no_segments_fetched = {
     "enabled": False,
     "ruleKey": "default-rollout-52207-23726430538",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": true,
+    "isEveryoneElseVariation": True,
     "userContext": {
         "userId": "test_user",
         "attributes": {}
@@ -46,7 +46,7 @@ expected_fetch_enabled = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": false,
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -59,7 +59,7 @@ expected_fetch_enabled_default_rollout = {
     "enabled": False,
     "ruleKey": "default-rollout-52231-23726430538",
     "flagKey": "flag2",
-    "isEveryoneElseVariation": true,
+    "isEveryoneElseVariation": True,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}

--- a/tests/acceptance/test_acceptance/test_odp_redis.py
+++ b/tests/acceptance/test_acceptance/test_odp_redis.py
@@ -14,7 +14,7 @@ expected_redis_save = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": false,
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -27,7 +27,7 @@ expected_redis_lookup = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": false,
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-2",
         "attributes": {}
@@ -40,7 +40,7 @@ expected_redis_reset = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": false,
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-4",
         "attributes": {}

--- a/tests/acceptance/test_acceptance/test_odp_redis.py
+++ b/tests/acceptance/test_acceptance/test_odp_redis.py
@@ -14,7 +14,7 @@ expected_redis_save = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": False,
+    "isEveryoneElseVariation": false,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -27,7 +27,7 @@ expected_redis_lookup = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": False,
+    "isEveryoneElseVariation": false,
     "userContext": {
         "userId": "matjaz-user-2",
         "attributes": {}
@@ -40,7 +40,7 @@ expected_redis_reset = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
-    "isEveryoneElseVariation": False,
+    "isEveryoneElseVariation": false,
     "userContext": {
         "userId": "matjaz-user-4",
         "attributes": {}

--- a/tests/acceptance/test_acceptance/test_odp_redis.py
+++ b/tests/acceptance/test_acceptance/test_odp_redis.py
@@ -14,6 +14,7 @@ expected_redis_save = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-1",
         "attributes": {}
@@ -26,6 +27,7 @@ expected_redis_lookup = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-2",
         "attributes": {}
@@ -38,6 +40,7 @@ expected_redis_reset = {
     "enabled": True,
     "ruleKey": "ab_experiment",
     "flagKey": "flag1",
+    "isEveryoneElseVariation": False,
     "userContext": {
         "userId": "matjaz-user-4",
         "attributes": {}

--- a/tests/acceptance/test_acceptance/test_ups.py
+++ b/tests/acceptance/test_acceptance/test_ups.py
@@ -25,7 +25,7 @@ def test_ups__feature(session_obj):
         {
           "variationKey": "variation_1",
           "enabled": true,
-          "isEveryoneElseVariation": False,
+          "isEveryoneElseVariation": false,
           "ruleKey": "feature_2_test",
           "flagKey": "feature_2",
           "userContext": {
@@ -99,7 +99,7 @@ def test_ups__save(session_obj):
             "variationKey": "variation_2",
             "enabled": true,
             "ruleKey": "feature_2_test",
-            "isEveryoneElseVariation": False,
+            "isEveryoneElseVariation": false,
             "flagKey": "feature_2",
             "userContext": {
                 "userId": "user1",

--- a/tests/acceptance/test_acceptance/test_ups.py
+++ b/tests/acceptance/test_acceptance/test_ups.py
@@ -25,6 +25,7 @@ def test_ups__feature(session_obj):
         {
           "variationKey": "variation_1",
           "enabled": true,
+          "isEveryoneElseVariation": False,
           "ruleKey": "feature_2_test",
           "flagKey": "feature_2",
           "userContext": {
@@ -98,6 +99,7 @@ def test_ups__save(session_obj):
             "variationKey": "variation_2",
             "enabled": true,
             "ruleKey": "feature_2_test",
+            "isEveryoneElseVariation": False,
             "flagKey": "feature_2",
             "userContext": {
                 "userId": "user1",
@@ -186,7 +188,8 @@ def test_ups__save_with_invalid_payload(session_obj):
                     "attr_1": "hola"
                 }
             },
-            "reasons": []
+            "reasons": [],
+            "isEveryoneElseVariation": False
         }
     """
 

--- a/tests/acceptance/test_acceptance/test_ups.py
+++ b/tests/acceptance/test_acceptance/test_ups.py
@@ -189,7 +189,7 @@ def test_ups__save_with_invalid_payload(session_obj):
                 }
             },
             "reasons": [],
-            "isEveryoneElseVariation": False
+            "isEveryoneElseVariation": false
         }
     """
 


### PR DESCRIPTION
## Summary
- added IsEveryoneElseVariation marker in decide API

## Ticket
- [FSSDK-10553](https://jira.sso.episerver.net/browse/FSSDK-10553)
