### PR TITLE
[FSSDK-10734] update regex to allow `=` character

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -170,6 +170,7 @@ client:
     ## the maximum time between events being dispatched
     flushInterval: 30s
     ## Template URL for SDK datafile location. The template should specify a "%s" token for SDK key substitution.
+    ## For secure environments, the datafileURLTemplate should be set to "https://config.optimizely.com/datafiles/auth/%s.json"
     datafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json"
     ## URL for dispatching events.
     eventURL: "https://logx.optimizely.com/v1/events"

--- a/config.yaml
+++ b/config.yaml
@@ -177,7 +177,7 @@ client:
     ## Validation Regex on the request SDK Key
     ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
     ## https://github.com/google/re2/wiki/Syntax
-    SdkKeyRegex: "^[a-zA-Z0-9=-]+(:[a-zA-Z0-9=-]+)?$"
+    sdkKeyRegex: "^[\\w=]+(:[\\w=]+)?$"
     ## configure optional User profile service
     userProfileService:
       default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -177,7 +177,7 @@ client:
     ## Validation Regex on the request SDK Key
     ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
     ## https://github.com/google/re2/wiki/Syntax
-    sdkKeyRegex: "^\\w+(:\\w+)?$"
+    SdkKeyRegex: "^[a-zA-Z0-9=-]+(:[a-zA-Z0-9=-]+)?$"
     ## configure optional User profile service
     userProfileService:
       default: ""

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ func NewDefaultConfig() *AgentConfig {
 			DatafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json",
 			EventURL:            "https://logx.optimizely.com/v1/events",
 			// https://github.com/google/re2/wiki/Syntax
-			SdkKeyRegex: "^[a-zA-Z0-9=-]+(:[a-zA-Z0-9=-]+)?$",
+			SdkKeyRegex: "^[\\w=]+(:[\\w=]+)?$",
 			UserProfileService: UserProfileServiceConfigs{
 				"default":  "",
 				"services": map[string]interface{}{},

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ func NewDefaultConfig() *AgentConfig {
 			DatafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json",
 			EventURL:            "https://logx.optimizely.com/v1/events",
 			// https://github.com/google/re2/wiki/Syntax
-			SdkKeyRegex: "^\\w+(:\\w+)?$",
+			SdkKeyRegex: "^[a-zA-Z0-9=-]+(:[a-zA-Z0-9=-]+)?$",
 			UserProfileService: UserProfileServiceConfigs{
 				"default":  "",
 				"services": map[string]interface{}{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,7 +82,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, conf.Client.FlushInterval)
 	assert.Equal(t, "https://cdn.optimizely.com/datafiles/%s.json", conf.Client.DatafileURLTemplate)
 	assert.Equal(t, "https://logx.optimizely.com/v1/events", conf.Client.EventURL)
-	assert.Equal(t, "^\\w+(:\\w+)?$", conf.Client.SdkKeyRegex)
+	assert.Equal(t, "^[\\w=]+(:[\\w=]+)?$", conf.Client.SdkKeyRegex)
 	assert.Equal(t, "", conf.Client.UserProfileService["default"])
 	assert.Equal(t, false, conf.Client.ODP.Disable)
 	assert.Equal(t, 1*time.Second, conf.Client.ODP.EventsFlushInterval)

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -780,6 +780,7 @@ func (s *DefaultLoaderTestSuite) TestDefaultRegexValidator() {
 		{":", false},
 		{"abc:def:hij", false},
 		{"abc:", false},
+		{"123sdkKey:accesTokenWith=", true},
 	}
 
 	conf := config.NewDefaultConfig()


### PR DESCRIPTION
## Summary
- updated config.yaml
- updated regex to allow `=` character

## Issues
- [FSSDK-10734](https://jira.sso.episerver.net/browse/FSSDK-10734)
