### PR TITLE
[FSSDK-10734] update regex to support base64 char for SDK Key & access token

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -177,7 +177,7 @@ client:
     ## Validation Regex on the request SDK Key
     ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
     ## https://github.com/google/re2/wiki/Syntax
-    sdkKeyRegex: "^[a-zA-Z0-9+/=]+(:[a-zA-Z0-9+/=]+)?$"
+    sdkKeyRegex: "^[a-zA-Z0-9+/=_]+(:[a-zA-Z0-9+/=_]+)?$"
     ## configure optional User profile service
     userProfileService:
       default: ""

--- a/config.yaml
+++ b/config.yaml
@@ -177,7 +177,7 @@ client:
     ## Validation Regex on the request SDK Key
     ## By default Agent assumes only alphanumeric characters as part of the SDK Key string.
     ## https://github.com/google/re2/wiki/Syntax
-    sdkKeyRegex: "^[\\w=]+(:[\\w=]+)?$"
+    sdkKeyRegex: "^[a-zA-Z0-9+/=]+(:[a-zA-Z0-9+/=]+)?$"
     ## configure optional User profile service
     userProfileService:
       default: ""

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ func NewDefaultConfig() *AgentConfig {
 			DatafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json",
 			EventURL:            "https://logx.optimizely.com/v1/events",
 			// https://github.com/google/re2/wiki/Syntax
-			SdkKeyRegex: "^[a-zA-Z0-9+/=]+(:[a-zA-Z0-9+/=]+)?$",
+			SdkKeyRegex: "^[a-zA-Z0-9+/=_]+(:[a-zA-Z0-9+/=_]+)?$",
 			UserProfileService: UserProfileServiceConfigs{
 				"default":  "",
 				"services": map[string]interface{}{},

--- a/config/config.go
+++ b/config/config.go
@@ -82,7 +82,7 @@ func NewDefaultConfig() *AgentConfig {
 			DatafileURLTemplate: "https://cdn.optimizely.com/datafiles/%s.json",
 			EventURL:            "https://logx.optimizely.com/v1/events",
 			// https://github.com/google/re2/wiki/Syntax
-			SdkKeyRegex: "^[\\w=]+(:[\\w=]+)?$",
+			SdkKeyRegex: "^[a-zA-Z0-9+/=]+(:[a-zA-Z0-9+/=]+)?$",
 			UserProfileService: UserProfileServiceConfigs{
 				"default":  "",
 				"services": map[string]interface{}{},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,7 +82,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, conf.Client.FlushInterval)
 	assert.Equal(t, "https://cdn.optimizely.com/datafiles/%s.json", conf.Client.DatafileURLTemplate)
 	assert.Equal(t, "https://logx.optimizely.com/v1/events", conf.Client.EventURL)
-	assert.Equal(t, "^[a-zA-Z0-9+/=]+(:[a-zA-Z0-9+/=]+)?$", conf.Client.SdkKeyRegex)
+	assert.Equal(t, "^[a-zA-Z0-9+/=_]+(:[a-zA-Z0-9+/=_]+)?$", conf.Client.SdkKeyRegex)
 	assert.Equal(t, "", conf.Client.UserProfileService["default"])
 	assert.Equal(t, false, conf.Client.ODP.Disable)
 	assert.Equal(t, 1*time.Second, conf.Client.ODP.EventsFlushInterval)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -82,7 +82,7 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(t, 30*time.Second, conf.Client.FlushInterval)
 	assert.Equal(t, "https://cdn.optimizely.com/datafiles/%s.json", conf.Client.DatafileURLTemplate)
 	assert.Equal(t, "https://logx.optimizely.com/v1/events", conf.Client.EventURL)
-	assert.Equal(t, "^[\\w=]+(:[\\w=]+)?$", conf.Client.SdkKeyRegex)
+	assert.Equal(t, "^[a-zA-Z0-9+/=]+(:[a-zA-Z0-9+/=]+)?$", conf.Client.SdkKeyRegex)
 	assert.Equal(t, "", conf.Client.UserProfileService["default"])
 	assert.Equal(t, false, conf.Client.ODP.Disable)
 	assert.Equal(t, 1*time.Second, conf.Client.ODP.EventsFlushInterval)

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -772,7 +772,7 @@ func (s *DefaultLoaderTestSuite) TestDefaultRegexValidator() {
 		input    string
 		expected bool
 	}{
-		{"1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_", true},
+		{"1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", true},
 		{"12sdkKey:datafileAccessToken89", true},
 		{"!@#$%^&*()", false},
 		{"abc123!", false},

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -781,6 +781,11 @@ func (s *DefaultLoaderTestSuite) TestDefaultRegexValidator() {
 		{"abc:def:hij", false},
 		{"abc:", false},
 		{"123sdkKey:accesTokenWith=", true},
+		{"abc+123", true},
+		{"abc-123", false},
+		{"abc/123", true},
+		{"abc:def=", true},
+		{"abc:acd+def/=", true},
 	}
 
 	conf := config.NewDefaultConfig()

--- a/pkg/optimizely/cache_test.go
+++ b/pkg/optimizely/cache_test.go
@@ -772,7 +772,7 @@ func (s *DefaultLoaderTestSuite) TestDefaultRegexValidator() {
 		input    string
 		expected bool
 	}{
-		{"1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ", true},
+		{"1234567890abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ_", true},
 		{"12sdkKey:datafileAccessToken89", true},
 		{"!@#$%^&*()", false},
 		{"abc123!", false},

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -43,7 +43,7 @@ def session_override_sdk_key(session_obj):
     :param session_obj: session fixture object
     :return: updated session object
     """
-    session_obj.headers['X-Optimizely-SDK-Key'] = 'invalidsdkkey'
+    session_obj.headers['X-Optimizely-SDK-Key'] = 'xxx_invalid_sdk_key_xxx'
     return session_obj
 
 

--- a/tests/acceptance/test_acceptance/conftest.py
+++ b/tests/acceptance/test_acceptance/conftest.py
@@ -43,7 +43,7 @@ def session_override_sdk_key(session_obj):
     :param session_obj: session fixture object
     :return: updated session object
     """
-    session_obj.headers['X-Optimizely-SDK-Key'] = 'xxx_invalid_sdk_key_xxx'
+    session_obj.headers['X-Optimizely-SDK-Key'] = 'invalidsdkkey'
     return session_obj
 
 


### PR DESCRIPTION
## Summary
- add support for base64 char for SDK Key & access token

## Issues
- [FSSDK-10734](https://jira.sso.episerver.net/browse/FSSDK-10734)
